### PR TITLE
Replaced NULL with nullptr to fix build failure

### DIFF
--- a/Va416x0/Drv/I2cController/I2cController.cpp
+++ b/Va416x0/Drv/I2cController/I2cController.cpp
@@ -134,7 +134,7 @@ Drv::I2cStatus I2cController ::read_helper(U32 addr,              //!< I2C subor
 
     // Drain FIFO buffer to serBuffer
     U8* p_read_data = serBuffer.getData();
-    FW_ASSERT(p_read_data != NULL);
+    FW_ASSERT(p_read_data != nullptr);
     for (U32 i = 0; i < num_bytes_to_read; i++) {
         p_read_data[i] = U8(i2c_p.read_data() & Va416x0Mmio::I2c::DATA_VALUE_MASK);
     }


### PR DESCRIPTION
Updated `I2cController ::read_helper()` to use `nullptr` instead of `NULL` to fix a build failure with an updated version of [fpp ](https://github.com/nasa/fpp/tree/topology-code-for-direct-port-calls) and because `nullptr`  is the preferred approach. 