### PR TITLE
Exclude TimerRawTime test when using direct port calls

### DIFF
--- a/Va416x0/Os/TimerRawTime/CMakeLists.txt
+++ b/Va416x0/Os/TimerRawTime/CMakeLists.txt
@@ -64,6 +64,8 @@ register_fprime_implementation(
 # https://github.com/nasa/fpp/tree/topology-code-for-direct-port-calls), then only deployments can be built
 # This if assumes projects are not setting FW_DIRECT_PORT_CALLS unless also setting a 
 # cmake variable (CMAKE_FW_DIRECT_PORT_CALLS) to 1
+# The long term solution to this issue is to convert the test/impl directory to be a full deployment, 
+# see https://github.com/fprime-community/fprime-vorago/issues/15
 if ((NOT DEFINED CMAKE_FW_DIRECT_PORT_CALLS) OR (NOT CMAKE_FW_DIRECT_PORT_CALLS EQUAL 1))
     add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/test/impl")
 endif()


### PR DESCRIPTION
Building with direct port calls (added in https://github.com/nasa/fpp/tree/topology-code-for-direct-port-calls) requires that everything built with the FW_DIRECT_PORT_CALLS macro set to 1 is part of a deployment. 
The TimerRawTime impl test is not and is built for the same platform (va416x0-baremetal) that benefits from having FW_DIRECT_PORT_CALLS  set to 1. 
This update provides an opt-in mechanism for projects to disable the TimerRawTime impl test