### PR TITLE
Implement 'Va416x0Mmio::Amba::write_u8' with 'strb'

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -118,6 +118,7 @@ DVDD
 eabi
 ebi
 edata
+Ejh
 enb
 endforeach
 endfunction

--- a/Va416x0/Mmio/Amba/Amba.cpp
+++ b/Va416x0/Mmio/Amba/Amba.cpp
@@ -31,10 +31,10 @@ U8 read_u8(U32 bus_address) {
 }
 
 void write_u8(U32 bus_address, U8 value) {
-    __asm__ __volatile__("strb %1, [%0]"
-                         :  // No output operands
-                         : "r"(bus_address), "r"(value)
-                         : "memory"  // Clobber memory
+    asm volatile("strb %1, [%0]"
+                 :  // No output operands
+                 : "r"(bus_address), "r"(value)
+                 : "memory"  // Clobber memory
     );
 }
 

--- a/Va416x0/Mmio/Amba/Amba.cpp
+++ b/Va416x0/Mmio/Amba/Amba.cpp
@@ -31,7 +31,11 @@ U8 read_u8(U32 bus_address) {
 }
 
 void write_u8(U32 bus_address, U8 value) {
-    *reinterpret_cast<volatile U8*>(bus_address) = value;
+    __asm__ __volatile__("strb %1, [%0]"
+                         :  // No output operands
+                         : "r"(bus_address), "r"(value)
+                         : "memory"  // Clobber memory
+    );
 }
 
 U16 read_u16(U32 bus_address) {

--- a/cmake/toolchain/va416x0-baremetal.cmake
+++ b/cmake/toolchain/va416x0-baremetal.cmake
@@ -226,6 +226,10 @@ function(register_with_bsp TARGET_NAME)
         set(VA416X0_VERIFY_NO_STRB_WHITELIST
             ${VA416X0_VERIFY_NO_STRB_WHITELIST}
 
+            # We actually _do_ want 'strb' in 'Va416x0Mmio::Amba::write_u8'
+            # This uses inline assembly to avoid the `badstrb` feature
+            _ZN11Va416x0Mmio4Amba8write_u8Ejh
+
             # V-table data stored in .text
             __start___lcxx_override
 

--- a/cmake/toolchain/va416x0-baremetal.cmake
+++ b/cmake/toolchain/va416x0-baremetal.cmake
@@ -223,17 +223,17 @@ function(register_with_bsp TARGET_NAME)
 
     if (VA416X0_VERIFY_NO_STRB)
         # Define the default set of STRB whitelist
-        if (NOT DEFINED VA416X0_VERIFY_NO_STRB_WHITELIST)
-            set(VA416X0_VERIFY_NO_STRB_WHITELIST
-                # V-table data stored in .text
-                __start___lcxx_override
+        set(VA416X0_VERIFY_NO_STRB_WHITELIST
+            ${VA416X0_VERIFY_NO_STRB_WHITELIST}
 
-                # C vector table for initializing arrays
-                __preinit_array_start
-                __postinit_array_start
-                __init_array_start
-            )
-        endif()
+            # V-table data stored in .text
+            __start___lcxx_override
+
+            # C vector table for initializing arrays
+            __preinit_array_start
+            __postinit_array_start
+            __init_array_start
+        )
 
         add_custom_command("TARGET" "${TARGET_NAME}" POST_BUILD
             # Verify the .text of the objdump does not include illegal instructions

--- a/cmake/toolchain/verify_nostrb.py
+++ b/cmake/toolchain/verify_nostrb.py
@@ -87,7 +87,9 @@ def main():
                 continue
 
             # Rule out all instructions within the whitelist
-            if (function_name is None and symbol_name in whitelist) or function_name in whitelist:
+            if (
+                function_name is None and symbol_name in whitelist
+            ) or function_name in whitelist:
                 continue
 
             for i in illegal_instructions:
@@ -118,7 +120,7 @@ def main():
             + f" Illegal 8-bit operations detected in {target_name} with badstrb feature:",
             file=sys.stderr,
         )
-        for (instruction, function_name, symbol_name, location) in errors:
+        for instruction, function_name, symbol_name, location in errors:
             print(red("ERROR") + " Instruction " + red(instruction), file=sys.stderr)
             print(f"INFO     Function '{function_name}'", file=sys.stderr)
             print(f"INFO     Symbol '{symbol_name}'", file=sys.stderr)

--- a/cmake/toolchain/verify_nostrb.py
+++ b/cmake/toolchain/verify_nostrb.py
@@ -18,8 +18,7 @@
 import argparse
 import subprocess
 import sys
-import os
-import typing
+from typing import List, Optional, Tuple
 
 
 def red(sub: str):
@@ -51,7 +50,8 @@ def main():
     process = subprocess.Popen(
         [
             "arm-none-eabi-objdump",
-            "-d",
+            "-l",  # Source code line numbers
+            "-d",  # Decode only .text
             filename,
         ],
         stdout=subprocess.PIPE,
@@ -60,34 +60,54 @@ def main():
 
     assert process.stdout, "Failed to pipe stdout"
 
-    errors = []
+    errors: List[Tuple[str, Optional[str], Optional[str], Optional[str]]] = []
 
     # Clear lines until we get to the .text section
     for line in process.stdout:
         if "Disassembly of section .text" in line:
             break
 
+    # Symbol names are set in the .text by the linker
+    # These are the most robust labels in the final binary
+    symbol_name = None
+
+    # Function names are mapped via DWARF symbols and are typically per-instruction
+    function_name = None
+
+    # Location is the line number and file location this instruction corresponds to
+    # This information is also found in the DWARF symbols
+    location = None
+
+    illegal_instructions = ("strb", "strexb", "ldrexb")
+
     for line in process.stdout:
-        if line.endswith(">:\n"):
-            # This is a function section
-            func_name = line[line.find("<") + 1 : -3]
+        # This is an instruction
+        if line.startswith("    "):
+            if "__badstrb_strb" in line:
+                continue
 
-            for line in process.stdout:
-                if line == "\n":
-                    # Empty line marks the end of the function
-                    break
+            # Rule out all instructions within the whitelist
+            if (function_name is None and symbol_name in whitelist) or function_name in whitelist:
+                continue
 
-                if "__badstrb_strb" in line or func_name in whitelist:
-                    continue
+            for i in illegal_instructions:
+                if i in line:
+                    errors.append((i, function_name, symbol_name, location))
 
-                if "strb" in line:
-                    errors.append(f"Found {red('strb')} in '{func_name}'")
-
-                if "strexb" in line:
-                    errors.append(f"Found {red('strexb')} in '{func_name}'")
-
-                if "ldrexb" in line:
-                    errors.append(f"Found {red('ldrexb')} in '{func_name}'")
+        elif line.endswith(">:\n"):
+            symbol_name = line[line.find("<") + 1 : -3]
+        elif line.endswith("():\n"):
+            function_name = line[: line.find("():")]
+        else:
+            line = line.strip()
+            if line:
+                # All other non-empty lines are source locations
+                location = line.strip()
+            else:
+                # Empty lines mark the end of the function/symbol
+                symbol_name = None
+                function_name = None
+                location = None
 
     exit_code = process.wait()
     assert exit_code == 0, "objdump failed"
@@ -98,11 +118,14 @@ def main():
             + f" Illegal 8-bit operations detected in {target_name} with badstrb feature:",
             file=sys.stderr,
         )
-        for err in errors:
-            print(red("ERROR") + f"     {err}", file=sys.stderr)
-        print(f"INFO: Function whitelist:", file=sys.stderr)
+        for (instruction, function_name, symbol_name, location) in errors:
+            print(red("ERROR") + " Instruction " + red(instruction), file=sys.stderr)
+            print(f"INFO     Function '{function_name}'", file=sys.stderr)
+            print(f"INFO     Symbol '{symbol_name}'", file=sys.stderr)
+            print(f"INFO     Location '{location}'", file=sys.stderr)
+        print(f"INFO Function whitelist:", file=sys.stderr)
         for item in whitelist:
-            print(f"INFO:     {item}", file=sys.stderr)
+            print(f"INFO     {item}", file=sys.stderr)
         exit(1)
 
 


### PR DESCRIPTION
This PR does three things:

1. Makes `VA416X0_VERIFY_NO_STRB_WHITELIST` append to the default set of options that is builtin to the toolchain file
2. Implement `Va416x0Mmio::Amba::write_u8` with inline assembly to emit `strb` instead of `__badstrb_strb`
3. Changed the `verify_nostrb.py` to use a `-l` flag that marks instructions with their originating source line extracted from the DWARF symbols. The whitelist will reference this location since it's much less prone to inlining done during LTO.

Illegal `strb` errors now look like this:
```
ERROR Illegal 8-bit operations detected in Deployments_Breadboard1553BusCheck with badstrb feature:
ERROR Instruction strb
INFO     Function '_ZN11Va416x0Mmio4Amba8write_u8Ejh'
INFO     Symbol '_ZNK11Va416x0Mmio4Nvic16InterruptControl22set_interrupt_priorityEh'
INFO     Location '/workspaces/scythe/lib/fprime-vorago/Va416x0/Mmio/Amba/Amba.cpp:34'
INFO Function whitelist:
INFO     __init_array_start
INFO     __postinit_array_start
INFO     __start___lcxx_override
INFO     __preinit_array_start
```
