### PR TITLE
Updates to microscheduler to support new timestamping

### DIFF
--- a/Va416x0/Ports/TimePorts.fpp
+++ b/Va416x0/Ports/TimePorts.fpp
@@ -16,5 +16,5 @@
 
 module Va416x0 {
     port UpdateDuration(micros: U32)
-    port GetRtiTime() -> Va416x0Types.RtiTime
+    port GetRtiTime() -> Va416x0Types.RtiTimeWithValidity
 }

--- a/Va416x0/Svc/Microscheduler/Microscheduler.cpp
+++ b/Va416x0/Svc/Microscheduler/Microscheduler.cpp
@@ -124,6 +124,8 @@ void Microscheduler ::start_scheduler_handler(FwIndexType portNum) {
 
     // No need to set proxy_timer enabled yet. That will be taken care of
     // during the first top-of-RTI interrupt.
+
+    this->m_isRunning = true;
 }
 
 void Microscheduler ::update_duration_handler(FwIndexType portNum, U32 micros) {
@@ -142,7 +144,12 @@ void Microscheduler ::update_duration_handler(FwIndexType portNum, U32 micros) {
     main_timer.write_rst_value(micros * cycles_per_microsecond - 1);
 }
 
-Va416x0Types::RtiTime Microscheduler ::getRtiTime_handler(FwIndexType portNum) {
+Va416x0Types::RtiTimeWithValidity Microscheduler ::getRtiTime_handler(FwIndexType portNum) {
+    Va416x0Types::RtiTimeWithValidity rtiTimeV{false, Va416x0Types::RtiTime{0,0}};
+    if (!this->m_isRunning) {
+        rtiTimeV.set_isValid(false);
+        return rtiTimeV;
+    }
     // Lock to make sure that m_rtiIndex, m_rtiOffsetBase, and the main timer value are consistent.
     Va416x0Mmio::Lock::CriticalSectionLock lock;
 
@@ -157,7 +164,9 @@ Va416x0Types::RtiTime Microscheduler ::getRtiTime_handler(FwIndexType portNum) {
     FW_ASSERT(offsetUs <= config.maximum_duration_micros, offsetUs, this->m_rtiOffsetBase,
               config.maximum_duration_micros);
 
-    return Va416x0Types::RtiTime{this->m_rtiIndex, offsetUs};
+    rtiTimeV.set_isValid(true);
+    rtiTimeV.set_rtiTime(Va416x0Types::RtiTime{this->m_rtiIndex, offsetUs});
+    return rtiTimeV;
 }
 
 void Microscheduler ::main_timer_isr_handler(FwIndexType portNum) {

--- a/Va416x0/Svc/Microscheduler/Microscheduler.cpp
+++ b/Va416x0/Svc/Microscheduler/Microscheduler.cpp
@@ -145,7 +145,7 @@ void Microscheduler ::update_duration_handler(FwIndexType portNum, U32 micros) {
 }
 
 Va416x0Types::RtiTimeWithValidity Microscheduler ::getRtiTime_handler(FwIndexType portNum) {
-    Va416x0Types::RtiTimeWithValidity rtiTimeV{false, Va416x0Types::RtiTime{0,0}};
+    Va416x0Types::RtiTimeWithValidity rtiTimeV{false, Va416x0Types::RtiTime{0, 0}};
     if (!this->m_isRunning) {
         rtiTimeV.set_isValid(false);
         return rtiTimeV;

--- a/Va416x0/Svc/Microscheduler/Microscheduler.hpp
+++ b/Va416x0/Svc/Microscheduler/Microscheduler.hpp
@@ -68,7 +68,7 @@ class Microscheduler : public MicroschedulerComponentBase {
     //! Handler implementation for update_duration
     void update_duration_handler(FwIndexType portNum, U32 micros) override;
 
-    Va416x0Types::RtiTime getRtiTime_handler(FwIndexType portNum) override;
+    Va416x0Types::RtiTimeWithValidity getRtiTime_handler(FwIndexType portNum) override;
 
     //! Handler implementation for proxy_timer_isr
     void proxy_timer_isr_handler(FwIndexType portNum) override;
@@ -89,6 +89,9 @@ class Microscheduler : public MicroschedulerComponentBase {
     U32 execution_index;
     U32 m_rtiIndex;
     U32 m_rtiOffsetBase;
+
+    //! Flag indicating the scheduler has started
+    bool m_isRunning = false;
 };
 
 }  // namespace Va416x0Svc

--- a/Va416x0/Svc/Profiler/Profiler.cpp
+++ b/Va416x0/Svc/Profiler/Profiler.cpp
@@ -134,7 +134,7 @@ __attribute__((no_instrument_function)) void Profiler::run_handler(FwIndexType p
     // the RTI in the trace
     U8 trigger_rti = (this->m_rti == 0) ? (this->m_rtisPerSecond - 1) : (this->m_rti - 1);
     Va416x0Types::RtiTimeWithValidity rti_time = this->getRtiTime_out(0);
-    // FIXME - asserting that rti_time is valid may not be the best approach
+    // Assert that time is valid, as run should be invoked after the microscheduler starts
     FW_ASSERT(rti_time.get_isValid());
     if ((rti_time.get_rtiTime().get_rti() % this->m_rtisPerSecond) == trigger_rti) {
         this->enable();

--- a/Va416x0/Svc/Profiler/Profiler.cpp
+++ b/Va416x0/Svc/Profiler/Profiler.cpp
@@ -133,8 +133,10 @@ __attribute__((no_instrument_function)) void Profiler::run_handler(FwIndexType p
     // Enable the profiler on the RTI before the target RTI so that we can see the leading edge of
     // the RTI in the trace
     U8 trigger_rti = (this->m_rti == 0) ? (this->m_rtisPerSecond - 1) : (this->m_rti - 1);
-    Va416x0Types::RtiTime rti_time = this->getRtiTime_out(0);
-    if ((rti_time.get_rti() % this->m_rtisPerSecond) == trigger_rti) {
+    Va416x0Types::RtiTimeWithValidity rti_time = this->getRtiTime_out(0);
+    // FIXME - asserting that rti_time is valid may not be the best approach
+    FW_ASSERT(rti_time.get_isValid());
+    if ((rti_time.get_rtiTime().get_rti() % this->m_rtisPerSecond) == trigger_rti) {
         this->enable();
         this->m_rti = RTI_DISABLED;
     }

--- a/Va416x0/Types/Types.fpp
+++ b/Va416x0/Types/Types.fpp
@@ -32,6 +32,11 @@ module Va416x0Types {
         offsetUs: U32
     }
 
+    struct RtiTimeWithValidity {
+        isValid: bool
+        rtiTime: RtiTime
+    }
+
     constant BASE_NVIC_INTERRUPT = 16
     constant NUMBER_OF_EXCEPTIONS = BASE_NVIC_INTERRUPT + 196
 


### PR DESCRIPTION
There is a need to provide validity with the RtiTime value returned in getRtiTime.  RtiTime is valid after the scheduler starts in start_schedule_handler.