### PR TITLE
Shorten build IDs

### DIFF
--- a/cmake/autocoders/generate_build_info.py
+++ b/cmake/autocoders/generate_build_info.py
@@ -65,7 +65,7 @@ def get_project_root() -> str:
 
 
 def get_date() -> str:
-    output = subprocess.check_output(["date", "+%Y-%m-%d-%H-%M-%S"])
+    output = subprocess.check_output(["date", "+%Y%m%d-%H%M"])
     return output.decode().strip()
 
 


### PR DESCRIPTION
We shortened our build IDs to reduce the chance of build failures induced by long branch names. This change updates the fallback build IDs for local development to match the shortened format.