### PR TITLE
Add a constant for the number of APB1 timers

### DIFF
--- a/Va416x0/Mmio/ClkTree/ClkTree.cpp
+++ b/Va416x0/Mmio/ClkTree/ClkTree.cpp
@@ -178,8 +178,9 @@ U32 ClkTree::getPeripheralFreq(const Va416x0Mmio::SysConfig::ClockedPeripheral& 
 
 U32 ClkTree::getTimerFreq(Timer timer) const {
     //! Assert timer index is valid (TIM0-TIM23)
-    FW_ASSERT(timer.get_timer_peripheral_index() <= 23);
-    if (timer.get_timer_peripheral_index() <= 15) {
+    U8 timer_index = timer.get_timer_peripheral_index();
+    FW_ASSERT(timer_index < Timer::NUM_TIMERS, timer_index);
+    if (timer_index < Timer::NUM_APB1_TIMERS) {
         //! Timers 0-15 use APB1 Frequency
         return m_apb1_freq;
     } else {

--- a/Va416x0/Mmio/Timer/Timer.hpp
+++ b/Va416x0/Mmio/Timer/Timer.hpp
@@ -82,6 +82,8 @@ class Timer final {
     static constexpr U32 CSD_CTRL_CSDTRG2 = (1 << 10);
 
     static constexpr U32 NUM_TIMERS = 24;
+    //! Timers 0-15 reside on APB1, 16-23 reside on APB2
+    static constexpr U32 NUM_APB1_TIMERS = 16;
 
     U8 get_timer_peripheral_index() const;
 


### PR DESCRIPTION
Avoids the need for magic numbers, used in `Va416x0Mmio::ClkTree`