### PR TITLE
Add ClkTree dependency

### DIFF
--- a/Va416x0/Drv/PwmDriver/CMakeLists.txt
+++ b/Va416x0/Drv/PwmDriver/CMakeLists.txt
@@ -17,6 +17,7 @@ register_fprime_library(
         "${CMAKE_CURRENT_LIST_DIR}/PwmDriver.cpp"
   DEPENDS
         Va416x0_Mmio_Timer
+        Va416x0_Mmio_ClkTree
 )
 
 ### Unit Tests ###


### PR DESCRIPTION
Encountered a build error on a clean build that indicated the PwmDriver component hit an error due to missing ClkTree symbols.  We should add the dependency in the CMakeLists.txt file to prevent this compile error.