### PR TITLE
Fix Metronome initialization glitch

### DIFF
--- a/Va416x0/Os/AtomicMutex/AtomicMutex.cpp
+++ b/Va416x0/Os/AtomicMutex/AtomicMutex.cpp
@@ -37,7 +37,6 @@ Os::MutexHandle* AtomicMutex::getHandle() {
 }  // namespace AtomicMutex
 }  // namespace Va416x0Os
 
-
 namespace Os {
 
 //! \brief get a delegate for MutexInterface that intercepts calls for stub file usage
@@ -48,4 +47,4 @@ MutexInterface* MutexInterface::getDelegate(MutexHandleStorage& aligned_new_memo
     return Os::Delegate::makeDelegate<MutexInterface, Va416x0Os::AtomicMutex::AtomicMutex>(aligned_new_memory);
 }
 
-}
+}  // namespace Os

--- a/Va416x0/Svc/Metronome/Metronome.cpp
+++ b/Va416x0/Svc/Metronome/Metronome.cpp
@@ -112,14 +112,15 @@ void Metronome ::start_metronome_handler(FwIndexType portNum) {
     proxy_timer.write_cnt_value(0);
     proxy_timer.write_ctrl(Va416x0Mmio::Timer::CTRL_ENABLE | Va416x0Mmio::Timer::CTRL_IRQ_ENB);
 
+    // Before we start the timer, mark the metronome as running so that times are considered valid.
+    this->m_isRunning = true;
+
     // Go.
     main_ic.set_interrupt_enabled(true);
     main_timer.write_enable(1);
 
     // No need to set proxy_timer enabled yet. That will be taken care of
     // during the first top-of-RTI interrupt.
-
-    this->m_isRunning = true;
 }
 
 void Metronome ::update_duration_handler(FwIndexType portNum, U32 micros) {


### PR DESCRIPTION
If `m_isRunning` is set _after_ the interrupt is enabled, then the interrupt could potentially fire before `m_isRunning` becomes true. Fix the ordering.

Tested by @bdshenker.