### PR TITLE
Add the ability to enable input reading on output pins

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -162,6 +162,7 @@ IABR
 ICER
 ICPR
 icsr
+IEWO
 ihex
 indexstr
 INOUT
@@ -221,6 +222,7 @@ mmfar
 mmfr
 mmfsr
 Mmio
+mno
 mosi
 movt
 msr

--- a/Va416x0/Mmio/Gpio/Pin.cpp
+++ b/Va416x0/Mmio/Gpio/Pin.cpp
@@ -261,7 +261,7 @@ void Pin::configure_as_gpio(Fw::Direction dir,
                             Gpio::Irq irq,
                             bool direct_interrupt,
                             Gpio::Resistors resistors,
-                            bool enable_input_read_back) const {
+                            Gpio::InputEnable enable_input_read_back) const {
     // Assert that direction is only IN or OUT; INOUT is not supported in the Vorago
     FW_ASSERT(dir == Fw::Direction::IN || dir == Fw::Direction::OUT, dir);
     // Re-enforce IoConfig and GPIO clock enabled.
@@ -277,7 +277,7 @@ void Pin::configure_as_gpio(Fw::Direction dir,
         config |= IoConfig::IO_CONFIG_PEN | IoConfig::IO_CONFIG_PLEVEL_PULLDOWN;
     }
     // If requested, enable input read back
-    if (enable_input_read_back) {
+    if (enable_input_read_back == Gpio::INPUT_ENABLED_ON_OUTPUT) {
         config |= IoConfig::IO_CONFIG_IEWO;
     }
     IoConfig::write_port_config(gpio_port.get_gpio_port(), gpio_pin, config);

--- a/Va416x0/Mmio/Gpio/Pin.cpp
+++ b/Va416x0/Mmio/Gpio/Pin.cpp
@@ -261,7 +261,7 @@ void Pin::configure_as_gpio(Fw::Direction dir,
                             Gpio::Irq irq,
                             bool direct_interrupt,
                             Gpio::Resistors resistors,
-                            bool enable_input_readback) const {
+                            bool enable_input_read_back) const {
     // Assert that direction is only IN or OUT; INOUT is not supported in the Vorago
     FW_ASSERT(dir == Fw::Direction::IN || dir == Fw::Direction::OUT, dir);
     // Re-enforce IoConfig and GPIO clock enabled.
@@ -277,7 +277,7 @@ void Pin::configure_as_gpio(Fw::Direction dir,
         config |= IoConfig::IO_CONFIG_PEN | IoConfig::IO_CONFIG_PLEVEL_PULLDOWN;
     }
     // If requested, enable input read back
-    if (enable_input_readback) {
+    if (enable_input_read_back) {
         config |= IoConfig::IO_CONFIG_IEWO;
     }
     IoConfig::write_port_config(gpio_port.get_gpio_port(), gpio_pin, config);

--- a/Va416x0/Mmio/Gpio/Pin.cpp
+++ b/Va416x0/Mmio/Gpio/Pin.cpp
@@ -276,7 +276,7 @@ void Pin::configure_as_gpio(Fw::Direction dir,
     } else if (resistors == Gpio::PULL_DOWN) {
         config |= IoConfig::IO_CONFIG_PEN | IoConfig::IO_CONFIG_PLEVEL_PULLDOWN;
     }
-    // If requested, enable input readback
+    // If requested, enable input read back
     if (enable_input_readback) {
         config |= IoConfig::IO_CONFIG_IEWO;
     }

--- a/Va416x0/Mmio/Gpio/Pin.cpp
+++ b/Va416x0/Mmio/Gpio/Pin.cpp
@@ -260,7 +260,8 @@ void Pin::configure_as_gpio(Fw::Direction dir,
                             Gpio::Delay delay,
                             Gpio::Irq irq,
                             bool direct_interrupt,
-                            Gpio::Resistors resistors) const {
+                            Gpio::Resistors resistors,
+                            bool enable_input_readback) const {
     // Assert that direction is only IN or OUT; INOUT is not supported in the Vorago
     FW_ASSERT(dir == Fw::Direction::IN || dir == Fw::Direction::OUT, dir);
     // Re-enforce IoConfig and GPIO clock enabled.
@@ -274,6 +275,10 @@ void Pin::configure_as_gpio(Fw::Direction dir,
         config |= IoConfig::IO_CONFIG_PEN | IoConfig::IO_CONFIG_PLEVEL_PULLUP;
     } else if (resistors == Gpio::PULL_DOWN) {
         config |= IoConfig::IO_CONFIG_PEN | IoConfig::IO_CONFIG_PLEVEL_PULLDOWN;
+    }
+    // If requested, enable input readback
+    if (enable_input_readback) {
+        config |= IoConfig::IO_CONFIG_IEWO;
     }
     IoConfig::write_port_config(gpio_port.get_gpio_port(), gpio_pin, config);
 

--- a/Va416x0/Mmio/Gpio/Pin.hpp
+++ b/Va416x0/Mmio/Gpio/Pin.hpp
@@ -78,7 +78,7 @@ class Pin final {
                            Gpio::Irq irq = Gpio::IRQ_DEFAULT,
                            bool direct_interrupt = false,
                            Gpio::Resistors resistors = Gpio::PULL_NEITHER,
-                           bool enable_input_readback = false) const;
+                           bool enable_input_read_back = false) const;
 
     // Will trip an assertion if the function in question cannot be routed to this pin.
     void configure_as_function(Signal::FunctionSignal function, Gpio::IoInversion inversion = Gpio::NO_CHANGE) const;

--- a/Va416x0/Mmio/Gpio/Pin.hpp
+++ b/Va416x0/Mmio/Gpio/Pin.hpp
@@ -77,7 +77,8 @@ class Pin final {
                            Gpio::Delay delay = Gpio::NO_DELAY,
                            Gpio::Irq irq = Gpio::IRQ_DEFAULT,
                            bool direct_interrupt = false,
-                           Gpio::Resistors resistors = Gpio::PULL_NEITHER) const;
+                           Gpio::Resistors resistors = Gpio::PULL_NEITHER,
+                           bool enable_input_readback = false) const;
 
     // Will trip an assertion if the function in question cannot be routed to this pin.
     void configure_as_function(Signal::FunctionSignal function, Gpio::IoInversion inversion = Gpio::NO_CHANGE) const;

--- a/Va416x0/Mmio/Gpio/Pin.hpp
+++ b/Va416x0/Mmio/Gpio/Pin.hpp
@@ -60,6 +60,8 @@ enum IoInversion {
     INVERT,
 };
 
+enum InputEnable { INPUT_NOT_ENABLED_ON_OUTPUT, INPUT_ENABLED_ON_OUTPUT };
+
 class Pin final {
   public:
     // Note: This is not the recommended way to reference a pin.
@@ -78,7 +80,7 @@ class Pin final {
                            Gpio::Irq irq = Gpio::IRQ_DEFAULT,
                            bool direct_interrupt = false,
                            Gpio::Resistors resistors = Gpio::PULL_NEITHER,
-                           bool enable_input_read_back = false) const;
+                           Gpio::InputEnable enable_input_read_back = Gpio::INPUT_NOT_ENABLED_ON_OUTPUT) const;
 
     // Will trip an assertion if the function in question cannot be routed to this pin.
     void configure_as_function(Signal::FunctionSignal function, Gpio::IoInversion inversion = Gpio::NO_CHANGE) const;

--- a/Va416x0/Mmio/IoConfig/IoConfig.hpp
+++ b/Va416x0/Mmio/IoConfig/IoConfig.hpp
@@ -24,6 +24,7 @@ namespace Va416x0Mmio {
 namespace IoConfig {
 
 constexpr U32 IO_CONFIG_INVINP = 1 << 6;
+constexpr U32 IO_CONFIG_IEWO = 1 << 7;
 constexpr U32 IO_CONFIG_INVOUT = 1 << 9;
 constexpr U32 IO_CONFIG_PLEVEL_PULLDOWN = 0 << 10;
 constexpr U32 IO_CONFIG_PLEVEL_PULLUP = 1 << 10;


### PR DESCRIPTION
During some testing of output pins, I noticed that reading back the state of the pins via `in()` always returned 0. Reading through the VA416x0 Programmers Guide v1.2, I noted that the bit IEWO (bit 7 in the IO config register) must be set in order to use `in()`. We may not want to blanket set that configuration setting for all output pins, so it makes more sense to add it as an option to the `configure_as_gpio` function and let individual pins set that explicitly. Add that capability to the configuration of GPIO pins as the last argument field to not impact current users of that function.