### PR TITLE
Update AdcSampler config and allow MUX_EN pins to reside on multiple ports

### DIFF
--- a/Va416x0/Drv/AdcSampler/AdcSampler.cpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.cpp
@@ -20,6 +20,7 @@
 // ======================================================================
 
 #include "Va416x0/Drv/AdcSampler/AdcSampler.hpp"
+#include "Os/RawTime.hpp"
 #include "Va416x0/Mmio/Adc/Adc.hpp"
 #include "Va416x0/Mmio/Amba/Amba.hpp"
 #include "Va416x0/Mmio/ClkTree/ClkTree.hpp"
@@ -29,18 +30,17 @@
 #include "Va416x0/Mmio/Lock/Lock.hpp"
 #include "Va416x0/Mmio/Nvic/Nvic.hpp"
 #include "Va416x0/Mmio/SysConfig/SysConfig.hpp"
-#include "lib/fprime/Os/RawTime.hpp"
 
 namespace Va416x0 {
 
 /* Each AdcRequest (U32 value) is a bit packed structure with the following fields:
- field name | Bits  | Description
+ Field name | Bits  | Description
     chan_en | 31-16 | this is a bit mask (to read channel 7, this should be (1<<7))
-    cnt     | 15-12 | range 0 to 15 supports 1 to 16 samples
-  enable_pin| 11-8  | supports mux_en pins 0 to 15
+        cnt | 15-12 | range 0 to 15 supports 1 to 16 samples
+ enable_pin | 11-8  | supports mux_en pins 0 to 15
    mux_chan | 8-2   | supports mux addresses 0 to 31
-    is_mux  | 1     | indicates whether MUX enable & address values should be set
-   is_sweep | 0    | controls whether N+1 channels are read once or 1 channel is read N+1 times
+     is_mux | 1     | indicates whether MUX enable & address values should be set
+   is_sweep | 0     | controls whether N+1 channels are read once or 1 channel is read N+1 times
 */
 static inline U32 REQ_GET_CHAN_EN(U32 request) {
     return request >> 16;
@@ -67,138 +67,126 @@ static inline U32 REQ_GET_IS_SWEEP(U32 request) {
 }
 
 constexpr U32 MICROSECONDS_PER_SECOND = 1000 * 1000;
-constexpr U32 NANOSECONDS_PER_SECOND = 1000000000;
-constexpr U32 MULTIPLEXER_BREAK_BEFORE_MAKE_DELAY_NS = 100;
+constexpr U32 NANOSECONDS_PER_SECOND = MICROSECONDS_PER_SECOND * 1000;
+//! 100ns delay following the MUX being enabled or disabled
+constexpr U32 MUX_BREAK_BEFORE_MAKE_DELAY_NS = 100;
 
 // ----------------------------------------------------------------------
 // Component construction and destruction
 // ----------------------------------------------------------------------
 
-AdcSampler ::AdcSampler(const char* const compName) : AdcSamplerComponentBase(compName) {
-    this->m_pRequests = nullptr;
-    this->m_pData = nullptr;
-    this->m_curRequest = 0;
-    this->m_numReads = 0;
-    this->m_requestIndex.store(0);
-    this->m_adcDelayTicks = 0;
+AdcSampler::AdcSampler(const char* const compName)
+    : AdcSamplerComponentBase(compName),
+      m_config(nullptr),
+      m_pRequests(nullptr),
+      m_pData(nullptr),
+      m_curRequest(0),
+      m_numReads(0),
+      m_adcDelayTicks(0) {
+    for (U32 i = 0; i < Va416x0Mmio::Gpio::NUM_PORTS; i++) {
+        this->m_muxPinsMask[i] = 0;
+        this->m_lastPinsValue[i] = 0;
+    }
 }
 
-void AdcSampler ::setup(AdcConfig& config,
-                        U32 adc_delay_microseconds,
-                        Va416x0Mmio::Timer timer,
-                        U8 adc_interrupt_priority,
-                        U8 timer_interrupt_priority) {
+void AdcSampler::configure(AdcConfig& config,
+                           U32 adc_delay_microseconds,
+                           Va416x0Mmio::Timer timer,
+                           U8 adc_interrupt_priority,
+                           U8 timer_interrupt_priority) {
+    FW_ASSERT(this->m_config == nullptr);
+    this->m_config = &config;
+
+    // Set up the timer used for the ADC delay
     this->m_timer = timer;
     Va416x0Mmio::SysConfig::set_clk_enabled(timer, true);
     Va416x0Mmio::SysConfig::reset_peripheral(timer);
+    timer.write_ctrl(Va416x0Mmio::Timer::CTRL_AUTO_DISABLE | Va416x0Mmio::Timer::CTRL_IRQ_ENB |
+                     Va416x0Mmio::Timer::CTRL_STATUS_PULSE);
+    timer.write_csd_ctrl(0);
     // Convert microseconds to ticks
     U32 timer_freq = Va416x0Mmio::ClkTree::getActiveTimerFreq(timer);
     U64 rstValueScaled = U64(timer_freq) * adc_delay_microseconds;
-
     this->m_adcDelayTicks = rstValueScaled / MICROSECONDS_PER_SECOND;
-    timer.write_csd_ctrl(0);
-    Va416x0Mmio::Nvic::InterruptControl timer_interrupt =
-        Va416x0Mmio::Nvic::InterruptControl(timer.get_timer_done_exception());
+
+    // Set up the interrupt that is triggered when the timer expires which is used as a trigger to
+    // start the ADC conversion
+    Va416x0Mmio::Nvic::InterruptControl timer_interrupt(timer.get_timer_done_exception());
     timer_interrupt.set_interrupt_pending(false);
     timer_interrupt.set_interrupt_priority(timer_interrupt_priority);
     Va416x0Mmio::SysConfig::set_clk_enabled(Va416x0Mmio::SysConfig::IRQ_ROUTER, true);
     Va416x0Mmio::Amba::memory_barrier();
     Va416x0Mmio::IrqRouter::write_adcsel(timer.get_timer_peripheral_index());
 
-    // Enable CLK for ADC
-    Va416x0Mmio::SysConfig::reset_peripheral(
-        Va416x0Mmio::SysConfig::ADC);  // not technically needed, but not a problem to do
+    // Enable CLK for ADC (not technically needed but not a problem to do)
+    Va416x0Mmio::SysConfig::reset_peripheral(Va416x0Mmio::SysConfig::ADC);
     Va416x0Mmio::SysConfig::set_clk_enabled(Va416x0Mmio::SysConfig::ADC, true);
 
-    // setup interrupt (I could make interrupt static, but I don't see a reason too yet)
-    Va416x0Mmio::Nvic::InterruptControl adc_interrupt =
-        Va416x0Mmio::Nvic::InterruptControl(Va416x0Types::ExceptionNumber::INTERRUPT_ADC);
+    // Set up the ADC interrupt
+    Va416x0Mmio::Nvic::InterruptControl adc_interrupt(Va416x0Types::ExceptionNumber::INTERRUPT_ADC);
     adc_interrupt.set_interrupt_pending(false);
     adc_interrupt.set_interrupt_enabled(true);
     adc_interrupt.set_interrupt_priority(adc_interrupt_priority);
 
-    // Configure the mux enable disable delay
+    // Configure the MUX enable/disable delay
     U32 sys_clock_rate = Va416x0Mmio::ClkTree::getActiveSysclkFreq();
-    this->m_muxEnaDisDelay = sys_clock_rate * MULTIPLEXER_BREAK_BEFORE_MAKE_DELAY_NS / NANOSECONDS_PER_SECOND;
-    FW_ASSERT(this->m_muxEnaDisDelay > 0, this->m_muxEnaDisDelay);
-
-    // FIXME: switch back to copy if no objects are in config
-    this->m_pConfig = &config;
+    this->m_muxEnaDisDelay = sys_clock_rate * MUX_BREAK_BEFORE_MAKE_DELAY_NS / NANOSECONDS_PER_SECOND;
+    FW_ASSERT(this->m_muxEnaDisDelay > 0, sys_clock_rate, MUX_BREAK_BEFORE_MAKE_DELAY_NS);
 
     // Configure GPIO pins for MUX(es) if using any
-    if (config.num_addr_pins != 0 || config.num_en_pins != 0) {
-        this->m_muxEnaGpioPort = config.gpio_port;
-
-        // NOTE: The below code initializes each pin separately, that's very inefficient but
-        // allows AdcSampler to offload the knowledge of default pin configuration to Pin.hpp
-        // So let's go with this unless/until we have initialization performance constraints
-
+    if ((config.num_addr_pins > 0) || (config.num_en_pins > 0)) {
         // Setup GPIO pins for mux enable signals (if any are used)
         FW_ASSERT(config.num_en_pins <= ADC_MUX_PINS_EN_MAX, config.num_en_pins);
-        for (U32 i = 0; i < Va416x0Mmio::Gpio::NUM_PORTS; i++) {
-            this->m_muxPinsMask[i] = 0;
-        }
-        this->m_muxEnPinsMask = 0;
-
         for (U32 i = 0; i < config.num_en_pins; i++) {
-            this->m_muxPinsMask[this->m_muxEnaGpioPort.value().get_gpio_port()] |=
-                (Fw::Logic::HIGH << config.mux_en_output[i]);
-            this->m_muxEnPinsMask |= (Fw::Logic::HIGH << config.mux_en_output[i]);
-            Va416x0Mmio::Gpio::Pin pin =
-                Va416x0Mmio::Gpio::Pin(this->m_muxEnaGpioPort.value(), config.mux_en_output[i]);
+            auto pin = &config.mux_en_output[i];
             // Default enable pins to HIGH (MUX disabled)
-            pin.out(Fw::Logic::HIGH);
-            pin.configure_as_gpio(Fw::Direction::OUT);
+            pin->out(Fw::Logic::HIGH);
+            pin->configure_as_gpio(Fw::Direction::OUT);
         }
 
         // Setup GPIO pins for mux address/selection signals (if any are used)
         FW_ASSERT(config.num_addr_pins <= ADC_MUX_PINS_ADDR_MAX, config.num_addr_pins);
         for (U32 i = 0; i < config.num_addr_pins; i++) {
-            this->m_muxPinsMask[config.mux_addr_output[i].getGpioPortNumber()] |=
-                (1 << config.mux_addr_output[i].getPinNumber());
-            config.mux_addr_output[i].configure_as_gpio(Fw::Direction::OUT);
+            auto pin = &config.mux_addr_output[i];
+            this->m_muxPinsMask[pin->getGpioPortNumber()] |= (1 << pin->getPinNumber());
+            pin->configure_as_gpio(Fw::Direction::OUT);
         }
     }
 
-    for (U32 i = 0; i < Va416x0Mmio::Gpio::NUM_PORTS; i++) {
-        this->m_lastPinsValue[i] = 0xffffffff;
-    }
-
-    // Dummy value to trigger delay on the first mux setup
+    // Dummy value to trigger a delay on the first MUX request
     this->m_lastMuxRequest = adc_sampler_request(0, 0, 0, 1, ADC_MUX_PINS_EN_MAX, 0);
 
     // This only enables the DONE interrupt (not overflow or underflow or error b/c those _shouldn't_ happen)
     // If AdcSamplerStatus is updated to include a FAILURE status, we could also enable
     // IRQ_ENB_FIFO_FULL & IRQ_ENB_FIFO_OFLOW & IRQ_ENB_FIFO_UFLOW & IRQ_ENB_TRIG_ERROR and have adcIrq_handler()
     // report failure if the IRQ_RAW register reports there's any interrupt bits set other than ADC_DONE
-    // but that would require another register read + logic (see notes in SRLAR-880 for an overhead estimate)
+    // but that would require another register read + logic
     Va416x0Mmio::Adc::write_irq_enb(Va416x0Mmio::Adc::IRQ_ENB_ADC_DONE);
     Va416x0Mmio::Adc::write_irq_clr(Va416x0Mmio::Adc::IRQ_CLR_ADC_DONE);
 }
 
-U32 AdcSampler ::getNumDataValues_handler(FwIndexType portNum) {
+U32 AdcSampler::getNumDataValues_handler(FwIndexType portNum) {
     return this->m_numReads == 0 ? 0 : this->m_dataIndex + 1;
 }
 // ----------------------------------------------------------------------
 // Handler implementations for typed input ports
 // ----------------------------------------------------------------------
 
-void AdcSampler ::adcIrq_handler(FwIndexType portNum) {
+void AdcSampler::adcIrq_handler(FwIndexType portNum) {
     // asserts are low cost compared to the register read/write and adds safety, so leave in
     FW_ASSERT(this->m_pData != nullptr && this->m_curRequest != 0);
     Va416x0Mmio::Adc::write_irq_clr(Va416x0Mmio::Adc::IRQ_CLR_ADC_DONE);
 
-    // NOTE: With extra overhead (see notes in SRLAR-880), we could check the status register
-    // NOTE: to ensure that the ADC isn't busy and the number of values matches
-    // NOTE: the expected count and then reflect that back in the status returned
-    // NOTE: from checkRead()
+    // NOTE: With extra overhead we could check the status register to ensure that the ADC is not
+    // busy and the number of values matches the expected count and then reflect that back in the
+    // status returned from checkRead
     // U32 status = Va416x0Mmio::Adc::read_status();
     // U32 num_samples = status & Va416x0Mmio::Adc::STATUS_FIFO_ENTRY_CNT_MASK;
     // this->m_readOk = (this->m_readOk) && (num_samples == cur_request_cnt && (status &
     // Va416x0Mmio::Adc::STATUS_IS_BUSY_MASK) == 0);
 
-    // If reading a single channel multiple times,
     if (REQ_GET_IS_SWEEP(this->m_curRequest) == 0 && this->m_curCnt > 0) {
+        // Reading a single channel multiple times
         FW_ASSERT((this->m_dataIndex) < this->m_pData->SIZE, this->m_requestIndex.load(), this->m_curRequest,
                   this->m_dataIndex, this->m_curCnt);
         // Sum up all the values & then store that sum in data[i]
@@ -208,8 +196,8 @@ void AdcSampler ::adcIrq_handler(FwIndexType portNum) {
         }
         (*this->m_pData)[this->m_dataIndex] = sum;
         this->m_dataIndex += 1;
-        // Otherwise, handle a sweep read OR a 1 time read of a single channel
     } else {
+        // Otherwise, handle a sweep read OR a 1 time read of a single channel
         FW_ASSERT((this->m_dataIndex + this->m_curCnt) < this->m_pData->SIZE, this->m_requestIndex.load(),
                   this->m_curRequest, this->m_dataIndex, this->m_curCnt);
         for (U32 n = 0; n < (this->m_curCnt + 1); n++) {
@@ -226,14 +214,15 @@ void AdcSampler ::adcIrq_handler(FwIndexType portNum) {
     }
 }
 
-Va416x0::AdcSamplerStatus AdcSampler ::checkRead_handler(FwIndexType portNum) {
+Va416x0::AdcSamplerStatus AdcSampler::checkRead_handler(FwIndexType portNum) {
     return this->m_requestIndex.load() < this->m_numReads ? Va416x0::AdcSamplerStatus::BUSY
                                                           : Va416x0::AdcSamplerStatus::SUCCESS;
 }
-bool AdcSampler ::startRead_handler(FwIndexType portNum,
-                                    U8 numReads,
-                                    Va416x0::AdcRequests& requests,
-                                    Va416x0::AdcData& data) {
+
+bool AdcSampler::startRead_handler(FwIndexType portNum,
+                                   U8 numReads,
+                                   Va416x0::AdcRequests& requests,
+                                   Va416x0::AdcData& data) {
     if (numReads == 0 || this->checkRead_handler(0) == Va416x0::AdcSamplerStatus::BUSY) {
         return false;
     }
@@ -248,70 +237,60 @@ bool AdcSampler ::startRead_handler(FwIndexType portNum,
     return true;
 }
 
-void AdcSampler ::startReadInner() {
-    // asserts are low cost compared to the register read/write and adds safety, so leave in
-    FW_ASSERT(
-        this->m_pRequests != nullptr && this->m_numReads > 0 && this->m_requestIndex.load() < this->m_pRequests->SIZE,
-        this->m_numReads);
-    this->m_curRequest = (*this->m_pRequests)[this->m_requestIndex];
+void AdcSampler::startReadInner() {
+    FW_ASSERT(this->m_config != nullptr);
+    FW_ASSERT(this->m_pRequests != nullptr);
+    FW_ASSERT(this->m_numReads > 0, this->m_numReads);
+
+    U32 requestIndex = this->m_requestIndex.load();
+    FW_ASSERT(requestIndex < this->m_pRequests->SIZE, requestIndex, this->m_pRequests->SIZE);
+    this->m_curRequest = (*this->m_pRequests)[requestIndex];
     this->m_curCnt = REQ_GET_CNT(this->m_curRequest);
-    FW_ASSERT(this->m_curRequest != 0, this->m_curRequest, this->m_requestIndex.load(), this->m_numReads);
+    FW_ASSERT(this->m_curRequest != 0, this->m_curRequest, requestIndex, this->m_numReads);
 
     // Handle MUX setup
-    U8 cur_mux_en_index = REQ_GET_MUX_ENABLE(this->m_curRequest);
-    U8 last_mux_en_index = REQ_GET_MUX_ENABLE(this->m_lastMuxRequest);
-
-    // The intention of this is to only enter this logic
-    // if the last recorded mux enable pin and the current requests
-    // mux enable pin are different AND the current request uses a mux
-    // last_mux_en_index == ADC_MUX_PINS_EN_MAX is used to catch the
-    // dummy value then short circuit the logic before invalid array indexing
-    if ((cur_mux_en_index < ADC_MUX_PINS_EN_MAX) &&
-        ((last_mux_en_index >= ADC_MUX_PINS_EN_MAX) ||
-         (this->m_pConfig->mux_en_output[last_mux_en_index] != this->m_pConfig->mux_en_output[cur_mux_en_index]))) {
-        Va416x0Mmio::Gpio::Port gpioPort = this->m_pConfig->gpio_port;
-        // Disable all MUX enable pins by setting them to 1
-        // Artificial block scope for scope lock
-        {
-            Va416x0Mmio::Lock::CriticalSectionLock lock;
-            gpioPort.write_datamask(this->m_muxEnPinsMask);
-            gpioPort.write_dataout(0xFFFFFFFF);
-        }
-
-        // Wait 100ns
-        Va416x0Mmio::Amba::memory_barrier();
-        Va416x0Mmio::Cpu::delay_cycles(this->m_muxEnaDisDelay);
-        this->m_lastMuxRequest = this->m_curRequest;
-    }
-
-    // See AdcCollector's SDD for more info.
     if (REQ_GET_IS_MUX(this->m_curRequest)) {
-        // NOTE: This only works as expected if all MUX enable pins come from the same GPIO port group.
-        // Otherwise this logic should be updated to first disable the previous MUX, then enable the next MUX,
-        // and then calculate the other pins to be set for the address pins.
-        for (U32 i = 0; i < Va416x0Mmio::Gpio::NUM_PORTS; i++) {
-            Va416x0Mmio::Gpio::Port gpioPort = Va416x0Mmio::Gpio::Port(i);
-            U32 pin_values = this->calculateGpioPinsValue(this->m_curRequest, gpioPort.get_gpio_port());
-
-            // Don't set the GPIO port if its new value matches the previous value
-            if (this->m_lastPinsValue[i] != pin_values) {
-                FW_ASSERT(this->m_muxEnaGpioPort.has_value());
-                // Disable interrupts to prevent a higher priority ISR writing DATAMASK on the same GPIO port
-                // Artificial block scope for scope lock
-                {
-                    Va416x0Mmio::Lock::CriticalSectionLock lock;
-                    gpioPort.write_datamask(this->m_muxPinsMask[i]);
-                    gpioPort.write_dataout(pin_values);
-                }
+        // First check if the MUX_EN pin for the current request is different from the MUX_EN pin
+        // for the previous MUX request
+        U8 muxEnIndex = REQ_GET_MUX_ENABLE(this->m_curRequest);
+        U8 previousMuxEnIndex = REQ_GET_MUX_ENABLE(this->m_lastMuxRequest);
+        if (muxEnIndex != previousMuxEnIndex) {
+            // Disable the previous MUX_EN pin, unless the previous pin index is the dummy value
+            // which indicates that no MUX request has been received yet
+            if (previousMuxEnIndex < ADC_MUX_PINS_EN_MAX) {
+                this->m_config->mux_en_output[previousMuxEnIndex].out(Fw::Logic::HIGH);
+                // Delay after disabling the previous MUX_EN pin
+                Va416x0Mmio::Amba::memory_barrier();
+                Va416x0Mmio::Cpu::delay_cycles(this->m_muxEnaDisDelay);
             }
-            this->m_lastPinsValue[i] = pin_values;
+
+            // Enable the new MUX_EN pin
+            FW_ASSERT(muxEnIndex < this->m_config->num_en_pins, muxEnIndex, this->m_curRequest,
+                      this->m_config->num_en_pins);
+            this->m_config->mux_en_output[muxEnIndex].out(Fw::Logic::LOW);
         }
+
+        // Calculate the values for the MUX address selection pins
+        for (U32 i = 0; i < Va416x0Mmio::Gpio::NUM_PORTS; i++) {
+            Va416x0Mmio::Gpio::Port port(i);
+            U32 pinValues = this->calculateGpioPinsValue(this->m_curRequest, i);
+            if (this->m_lastPinsValue[i] != pinValues) {
+                // Disable interrupts to prevent a higher priority ISR writing DATAMASK on the same GPIO port
+                Va416x0Mmio::Lock::CriticalSectionLock lock;
+                port.write_datamask(this->m_muxPinsMask[i]);
+                port.write_dataout(pinValues);
+            }
+            this->m_lastPinsValue[i] = pinValues;
+        }
+
+        // Save the MUX request
+        this->m_lastMuxRequest = this->m_curRequest;
     }
 
     // Clear FIFO & previous interrupt
     Va416x0Mmio::Adc::write_fifo_clr(Va416x0Mmio::Adc::FIFO_CLR_FIFO_CLR);
 
-    // Calculate the CTRL register value
+    // Calculate and write the CTRL register value
     // NOTE: The Programmers Guide says that CONV_CNT should be non-zero for sweep reads (see page 261)
     // However, testing showed that setting CONV_CNT to a non-zero value resulted in the sweep read
     // being done CONV_CNT + 1 times (e.g. CHAN_EN=0x7 resulted in 9 values being read & put in FIFO_DATA)
@@ -326,39 +305,28 @@ void AdcSampler ::startReadInner() {
          ((REQ_GET_IS_SWEEP(this->m_curRequest) == 1) ? Va416x0Mmio::Adc::CTRL_SWEEP_EN
                                                       : Va416x0Mmio::Adc::CTRL_SWEEP_DIS) +
          Va416x0Mmio::Adc::CTRL_EXT_TRIG_EN);
-
-    // Write control register
     Va416x0Mmio::Adc::write_ctrl(ctrl_val);
 
     // Setup and start timer
     FW_ASSERT(this->m_timer.has_value());
     this->m_timer.value().write_cnt_value(this->m_adcDelayTicks);
-    this->m_timer.value().write_ctrl(Va416x0Mmio::Timer::CTRL_ENABLE | Va416x0Mmio::Timer::CTRL_AUTO_DISABLE |
-                                     Va416x0Mmio::Timer::CTRL_IRQ_ENB | Va416x0Mmio::Timer::CTRL_STATUS_PULSE);
+    this->m_timer.value().write_enable(1);
 }
 
 U32 AdcSampler::calculateGpioPinsValue(U32 request, U32 port_number) {
     U32 pin_values = 0;
+    U8 numAddrPins = this->m_config->num_addr_pins;
     U8 mux_chan = REQ_GET_MUX_CHAN(request);
     U8 mux_en_index = REQ_GET_MUX_ENABLE(request);
-    FW_ASSERT(mux_chan < (1 << this->m_pConfig->num_addr_pins), mux_chan, this->m_pConfig->num_addr_pins);
+    FW_ASSERT(mux_chan < (1 << numAddrPins), mux_chan, numAddrPins);
+    FW_ASSERT(mux_en_index < numAddrPins, mux_en_index, numAddrPins);
+
     // The address pins should be set as a binary translation of the mux channel
     // where HI=1 and LO=0 (selecting Chan31 = 0b11111, selecting Chan0=0b0000)
-    for (U32 i = 0; i < this->m_pConfig->num_addr_pins; i++) {
-        if (this->m_pConfig->mux_addr_output[i].getGpioPortNumber() == port_number) {
-            if ((1 << i) & mux_chan) {
-                pin_values |= (1 << this->m_pConfig->mux_addr_output[i].getPinNumber());
-            }
-        }
-    }
-
-    // The enable pins should be set so that the pin for the MUX being read
-    // is LO (0) and all other pins are HI (1)
-    if (mux_en_index != ADC_MUX_PINS_EN_MAX) {
-        FW_ASSERT(mux_en_index < this->m_pConfig->num_en_pins, mux_en_index, this->m_pConfig->num_en_pins);
-        if (this->m_muxEnaGpioPort.value().get_gpio_port() == port_number) {
-            U32 en_mask = ~(1 << this->m_pConfig->mux_en_output[mux_en_index]);
-            pin_values |= (this->m_muxEnPinsMask & en_mask);
+    for (U32 i = 0; i < numAddrPins; i++) {
+        auto pin = &this->m_config->mux_addr_output[i];
+        if ((pin->getGpioPortNumber() == port_number) && ((1 << i) & mux_chan)) {
+            pin_values |= (1 << pin->getPinNumber());
         }
     }
 

--- a/Va416x0/Drv/AdcSampler/AdcSampler.cpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.cpp
@@ -34,13 +34,13 @@
 namespace Va416x0 {
 
 /* Each AdcRequest (U32 value) is a bit packed structure with the following fields:
- Field name | Bits  | Description
+ field name | Bits  | Description
     chan_en | 31-16 | this is a bit mask (to read channel 7, this should be (1<<7))
-        cnt | 15-12 | range 0 to 15 supports 1 to 16 samples
- enable_pin | 11-8  | supports mux_en pins 0 to 15
+    cnt     | 15-12 | range 0 to 15 supports 1 to 16 samples
+  enable_pin| 11-8  | supports mux_en pins 0 to 15
    mux_chan | 8-2   | supports mux addresses 0 to 31
-     is_mux | 1     | indicates whether MUX enable & address values should be set
-   is_sweep | 0     | controls whether N+1 channels are read once or 1 channel is read N+1 times
+    is_mux  | 1     | indicates whether MUX enable & address values should be set
+   is_sweep | 0    | controls whether N+1 channels are read once or 1 channel is read N+1 times
 */
 static inline U32 REQ_GET_CHAN_EN(U32 request) {
     return request >> 16;
@@ -89,34 +89,29 @@ AdcSampler::AdcSampler(const char* const compName)
     }
 }
 
-void AdcSampler::configure(AdcConfig& config,
-                           U32 adc_delay_microseconds,
-                           Va416x0Mmio::Timer timer,
-                           U8 adc_interrupt_priority,
-                           U8 timer_interrupt_priority) {
+void AdcSampler::configure(AdcConfig& config) {
     FW_ASSERT(this->m_config == nullptr);
     this->m_config = &config;
 
     // Set up the timer used for the ADC delay
-    this->m_timer = timer;
-    Va416x0Mmio::SysConfig::set_clk_enabled(timer, true);
-    Va416x0Mmio::SysConfig::reset_peripheral(timer);
-    timer.write_ctrl(Va416x0Mmio::Timer::CTRL_AUTO_DISABLE | Va416x0Mmio::Timer::CTRL_IRQ_ENB |
-                     Va416x0Mmio::Timer::CTRL_STATUS_PULSE);
-    timer.write_csd_ctrl(0);
+    Va416x0Mmio::SysConfig::set_clk_enabled(config.timer, true);
+    Va416x0Mmio::SysConfig::reset_peripheral(config.timer);
+    config.timer.write_ctrl(Va416x0Mmio::Timer::CTRL_AUTO_DISABLE | Va416x0Mmio::Timer::CTRL_IRQ_ENB |
+                            Va416x0Mmio::Timer::CTRL_STATUS_PULSE);
+    config.timer.write_csd_ctrl(0);
     // Convert microseconds to ticks
-    U32 timer_freq = Va416x0Mmio::ClkTree::getActiveTimerFreq(timer);
-    U64 rstValueScaled = U64(timer_freq) * adc_delay_microseconds;
+    U32 timer_freq = Va416x0Mmio::ClkTree::getActiveTimerFreq(config.timer);
+    U64 rstValueScaled = U64(timer_freq) * config.adcDelayUs;
     this->m_adcDelayTicks = rstValueScaled / MICROSECONDS_PER_SECOND;
 
     // Set up the interrupt that is triggered when the timer expires which is used as a trigger to
     // start the ADC conversion
-    Va416x0Mmio::Nvic::InterruptControl timer_interrupt(timer.get_timer_done_exception());
+    Va416x0Mmio::Nvic::InterruptControl timer_interrupt(config.timer.get_timer_done_exception());
     timer_interrupt.set_interrupt_pending(false);
-    timer_interrupt.set_interrupt_priority(timer_interrupt_priority);
+    timer_interrupt.set_interrupt_priority(config.timerInterruptPriority);
     Va416x0Mmio::SysConfig::set_clk_enabled(Va416x0Mmio::SysConfig::IRQ_ROUTER, true);
     Va416x0Mmio::Amba::memory_barrier();
-    Va416x0Mmio::IrqRouter::write_adcsel(timer.get_timer_peripheral_index());
+    Va416x0Mmio::IrqRouter::write_adcsel(config.timer.get_timer_peripheral_index());
 
     // Enable CLK for ADC (not technically needed but not a problem to do)
     Va416x0Mmio::SysConfig::reset_peripheral(Va416x0Mmio::SysConfig::ADC);
@@ -126,31 +121,32 @@ void AdcSampler::configure(AdcConfig& config,
     Va416x0Mmio::Nvic::InterruptControl adc_interrupt(Va416x0Types::ExceptionNumber::INTERRUPT_ADC);
     adc_interrupt.set_interrupt_pending(false);
     adc_interrupt.set_interrupt_enabled(true);
-    adc_interrupt.set_interrupt_priority(adc_interrupt_priority);
+    adc_interrupt.set_interrupt_priority(config.adcInterruptPriority);
 
     // Configure the MUX enable/disable delay
     U32 sys_clock_rate = Va416x0Mmio::ClkTree::getActiveSysclkFreq();
     this->m_muxEnaDisDelay = sys_clock_rate * MUX_BREAK_BEFORE_MAKE_DELAY_NS / NANOSECONDS_PER_SECOND;
     FW_ASSERT(this->m_muxEnaDisDelay > 0, sys_clock_rate, MUX_BREAK_BEFORE_MAKE_DELAY_NS);
 
-    // Configure GPIO pins for MUX(es) if using any
-    if ((config.num_addr_pins > 0) || (config.num_en_pins > 0)) {
-        // Setup GPIO pins for mux enable signals (if any are used)
-        FW_ASSERT(config.num_en_pins <= ADC_MUX_PINS_EN_MAX, config.num_en_pins);
-        for (U32 i = 0; i < config.num_en_pins; i++) {
-            auto pin = &config.mux_en_output[i];
-            // Default enable pins to HIGH (MUX disabled)
-            pin->out(Fw::Logic::HIGH);
-            pin->configure_as_gpio(Fw::Direction::OUT);
-        }
+    // Setup GPIO pins for MUX enable signals (if any are used)
+    if (config.muxEnPinCount > 0) {
+        FW_ASSERT(config.muxEnPins != nullptr, config.muxEnPinCount);
+    }
+    for (U32 i = 0; i < config.muxEnPinCount; i++) {
+        auto pin = &config.muxEnPins[i];
+        // Default enable pins to HIGH (MUX disabled)
+        pin->out(Fw::Logic::HIGH);
+        pin->configure_as_gpio(Fw::Direction::OUT);
+    }
 
-        // Setup GPIO pins for mux address/selection signals (if any are used)
-        FW_ASSERT(config.num_addr_pins <= ADC_MUX_PINS_ADDR_MAX, config.num_addr_pins);
-        for (U32 i = 0; i < config.num_addr_pins; i++) {
-            auto pin = &config.mux_addr_output[i];
-            this->m_muxPinsMask[pin->getGpioPortNumber()] |= (1 << pin->getPinNumber());
-            pin->configure_as_gpio(Fw::Direction::OUT);
-        }
+    // Setup GPIO pins for MUX address selection signals (if any are used)
+    if (config.muxAddrPinCount > 0) {
+        FW_ASSERT(config.muxAddrPins != nullptr, config.muxAddrPinCount);
+    }
+    for (U32 i = 0; i < config.muxAddrPinCount; i++) {
+        auto pin = &config.muxAddrPins[i];
+        this->m_muxPinsMask[pin->getGpioPortNumber()] |= (1 << pin->getPinNumber());
+        pin->configure_as_gpio(Fw::Direction::OUT);
     }
 
     // Dummy value to trigger a delay on the first MUX request
@@ -258,16 +254,16 @@ void AdcSampler::startReadInner() {
             // Disable the previous MUX_EN pin, unless the previous pin index is the dummy value
             // which indicates that no MUX request has been received yet
             if (previousMuxEnIndex < ADC_MUX_PINS_EN_MAX) {
-                this->m_config->mux_en_output[previousMuxEnIndex].out(Fw::Logic::HIGH);
+                this->m_config->muxEnPins[previousMuxEnIndex].out(Fw::Logic::HIGH);
                 // Delay after disabling the previous MUX_EN pin
                 Va416x0Mmio::Amba::memory_barrier();
                 Va416x0Mmio::Cpu::delay_cycles(this->m_muxEnaDisDelay);
             }
 
             // Enable the new MUX_EN pin
-            FW_ASSERT(muxEnIndex < this->m_config->num_en_pins, muxEnIndex, this->m_curRequest,
-                      this->m_config->num_en_pins);
-            this->m_config->mux_en_output[muxEnIndex].out(Fw::Logic::LOW);
+            FW_ASSERT(muxEnIndex < this->m_config->muxEnPinCount, muxEnIndex, this->m_curRequest,
+                      this->m_config->muxEnPinCount);
+            this->m_config->muxEnPins[muxEnIndex].out(Fw::Logic::LOW);
         }
 
         // Calculate the values for the MUX address selection pins
@@ -308,14 +304,13 @@ void AdcSampler::startReadInner() {
     Va416x0Mmio::Adc::write_ctrl(ctrl_val);
 
     // Setup and start timer
-    FW_ASSERT(this->m_timer.has_value());
-    this->m_timer.value().write_cnt_value(this->m_adcDelayTicks);
-    this->m_timer.value().write_enable(1);
+    this->m_config->timer.write_cnt_value(this->m_adcDelayTicks);
+    this->m_config->timer.write_enable(1);
 }
 
 U32 AdcSampler::calculateGpioPinsValue(U32 request, U32 port_number) {
     U32 pin_values = 0;
-    U8 numAddrPins = this->m_config->num_addr_pins;
+    U8 numAddrPins = this->m_config->muxAddrPinCount;
     U8 mux_chan = REQ_GET_MUX_CHAN(request);
     U8 mux_en_index = REQ_GET_MUX_ENABLE(request);
     FW_ASSERT(mux_chan < (1 << numAddrPins), mux_chan, numAddrPins);
@@ -324,7 +319,7 @@ U32 AdcSampler::calculateGpioPinsValue(U32 request, U32 port_number) {
     // The address pins should be set as a binary translation of the mux channel
     // where HI=1 and LO=0 (selecting Chan31 = 0b11111, selecting Chan0=0b0000)
     for (U32 i = 0; i < numAddrPins; i++) {
-        auto pin = &this->m_config->mux_addr_output[i];
+        auto pin = &this->m_config->muxAddrPins[i];
         if ((pin->getGpioPortNumber() == port_number) && ((1 << i) & mux_chan)) {
             pin_values |= (1 << pin->getPinNumber());
         }

--- a/Va416x0/Drv/AdcSampler/AdcSampler.cpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.cpp
@@ -126,9 +126,9 @@ void AdcSampler::configure(AdcConfig& config) {
     // Configure the MUX enable/disable delay
     U32 sys_clock_rate = Va416x0Mmio::ClkTree::getActiveSysclkFreq();
     this->m_muxEnaDisDelay = sys_clock_rate * MUX_BREAK_BEFORE_MAKE_DELAY_NS / NANOSECONDS_PER_SECOND;
-    FW_ASSERT(this->m_muxEnaDisDelay > 0, sys_clock_rate, MUX_BREAK_BEFORE_MAKE_DELAY_NS);
 
     // Setup GPIO pins for MUX enable signals (if any are used)
+    FW_ASSERT(config.muxEnPinCount < ADC_MUX_PINS_EN_MAX, config.muxEnPinCount, ADC_MUX_PINS_EN_MAX);
     if (config.muxEnPinCount > 0) {
         FW_ASSERT(config.muxEnPins != nullptr, config.muxEnPinCount);
     }
@@ -140,6 +140,7 @@ void AdcSampler::configure(AdcConfig& config) {
     }
 
     // Setup GPIO pins for MUX address selection signals (if any are used)
+    FW_ASSERT(config.muxAddrPinCount < ADC_MUX_PINS_ADDR_MAX, config.muxAddrPinCount, ADC_MUX_PINS_ADDR_MAX);
     if (config.muxAddrPinCount > 0) {
         FW_ASSERT(config.muxAddrPins != nullptr, config.muxAddrPinCount);
     }

--- a/Va416x0/Drv/AdcSampler/AdcSampler.fpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.fpp
@@ -15,11 +15,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 module Va416x0 {
-    
+
     @ Collects analog data from MUX or non-MUX channels using the VA41630 ADC peripheral
     passive component AdcSampler {
 
-        @ Read a contiguous selection of ADC channels 
+        @ Read a contiguous selection of ADC channels
         sync input port startRead: Va416x0.AdcStartRead
 
         @ Check whether ADC read request list is done

--- a/Va416x0/Drv/AdcSampler/AdcSampler.hpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.hpp
@@ -41,9 +41,9 @@
 /// @param enable_pin Index of the pin to set LO to enable the MUX for a MUX sample (ignored if is_mux is 0)
 /// @param mux_chan Channel (0 to 31) to select for the MUX sample (ignored if is_mux is 0)
 /// @return 32 bit unsigned int
-// FIXME: this should be namespaced
+// FIXME: should this be namespaced?
 U32 static inline adc_sampler_request(U16 chan_en, U8 cnt, bool is_sweep, bool is_mux, U8 enable_pin, U8 mux_chan) {
-    return (((chan_en & 0xffff) << 16) + ((cnt & 0xf) << 12) + ((enable_pin & 0xf) << 8) + ((mux_chan & 31) << 2) +
+    return (((chan_en & 0xffff) << 16) + ((cnt & 0xf) << 12) + ((enable_pin & 0xf) << 8) + ((mux_chan & 0x1f) << 2) +
             ((is_mux & 1) << 1) + ((is_sweep & 1) << 0));
 }
 
@@ -51,18 +51,26 @@ U32 static inline adc_sampler_request(U16 chan_en, U8 cnt, bool is_sweep, bool i
 namespace Va416x0 {
 
 struct AdcConfig {
-    //! Number of MUX_ADDR pins, can be between 0 (no MUXes) and ADC_MUX_PINS_ADDR_MAX
-    U8 num_addr_pins;
-    //! Number of MUX_EN pins, can be between 0 and ADC_MUX_PINS_EN_MAX
-    U8 num_en_pins;
-    //! Array of GPIO pins used to enable a MUX. If an ADC request specifies enable_pin=i, the pin
-    //! at index i is used. If a request specifies enable_pin=ADC_MUX_PINS_EN_MAX, no enable signal
-    //! is set
-    Va416x0Mmio::Gpio::Pin mux_en_output[ADC_MUX_PINS_EN_MAX];
-    //! Array of GPIO pins used for MUX address/selection. All MUXes must use the same pins for
-    //! address/selection signals. The pin at index i is the pin that sets 1 << i when selecting
+    //! Array of GPIO pins used to enable a MUX. When an ADC request specifies enable_pin=i, the
+    //! pin at index i is used. If a request specifies enable_pin=ADC_MUX_PINS_EN_MAX, no enable
+    //! signal is set
+    Va416x0Mmio::Gpio::Pin* muxEnPins;
+    //! Number of MUX_EN pins
+    U8 muxEnPinCount;
+    //! Array of GPIO pins used for MUX address selection. All MUXes must use the same pins for
+    //! address selection signals. The pin at index i is the pin that sets 1 << i when selecting
     //! the MUX channel
-    Va416x0Mmio::Gpio::Pin mux_addr_output[ADC_MUX_PINS_ADDR_MAX];
+    Va416x0Mmio::Gpio::Pin* muxAddrPins;
+    //! Number of MUX_ADDR pins
+    U8 muxAddrPinCount;
+    //! Delay (in microseconds) between the ADC request and when the sampling is performed
+    U32 adcDelayUs;
+    //! Timer used to perform the sampling delay
+    Va416x0Mmio::Timer timer;
+    //! Priority of the interrupt for the sampling delay timer
+    U8 timerInterruptPriority;
+    //! Priority of the ADC interrupt
+    U8 adcInterruptPriority;
 };
 
 class AdcSampler final : public AdcSamplerComponentBase {
@@ -78,11 +86,9 @@ class AdcSampler final : public AdcSamplerComponentBase {
     );
 
     //! Component configuration
-    void configure(AdcConfig& config,
-                   U32 adc_delay_microseconds,
-                   Va416x0Mmio::Timer timer,
-                   U8 timer_interrupt_priority,
-                   U8 adc_interrupt_priority);
+    //! NOTE: the AdcConfig struct must live beyond the call since it is stored as a pointer
+    //! member variable
+    void configure(AdcConfig& config);
 
   private:
     //! Pointer to the ADC configuration
@@ -107,8 +113,6 @@ class AdcSampler final : public AdcSamplerComponentBase {
     U32 m_dataIndex;
     //! Timer delay (in timer ticks) before triggering the ADC conversion
     U32 m_adcDelayTicks;
-    //! Timer used to perform the sampling delay
-    Va416x0Types::Optional<Va416x0Mmio::Timer> m_timer;
     //! Delay (in CPU cycles) after the MUX is enabled or disabled
     U32 m_muxEnaDisDelay;
     //! Last request which used a MUX

--- a/Va416x0/Drv/AdcSampler/AdcSampler.hpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.hpp
@@ -22,7 +22,6 @@
 #ifndef Va416x0_AdcSampler_HPP
 #define Va416x0_AdcSampler_HPP
 
-#include <atomic>
 #include "Va416x0/Drv/AdcSampler/AdcSamplerComponentAc.hpp"
 #include "Va416x0/Mmio/Gpio/Pin.hpp"
 #include "Va416x0/Mmio/Gpio/Port.hpp"
@@ -32,6 +31,8 @@
 #include "Va416x0/Types/FppConstantsAc.hpp"
 #include "Va416x0/Types/Optional.hpp"
 
+#include <atomic>
+
 /// @brief Combine channel mask, count, and other ADC request information into a U32 value
 /// @param chan_en Channel mask for the read (1 to 0xffff)
 /// @param cnt Number of samples to collect -1 (0 to 15)
@@ -40,41 +41,30 @@
 /// @param enable_pin Index of the pin to set LO to enable the MUX for a MUX sample (ignored if is_mux is 0)
 /// @param mux_chan Channel (0 to 31) to select for the MUX sample (ignored if is_mux is 0)
 /// @return 32 bit unsigned int
+// FIXME: this should be namespaced
 U32 static inline adc_sampler_request(U16 chan_en, U8 cnt, bool is_sweep, bool is_mux, U8 enable_pin, U8 mux_chan) {
     return (((chan_en & 0xffff) << 16) + ((cnt & 0xf) << 12) + ((enable_pin & 0xf) << 8) + ((mux_chan & 31) << 2) +
             ((is_mux & 1) << 1) + ((is_sweep & 1) << 0));
 }
 
+// FIXME: should be Va416x0Drv
 namespace Va416x0 {
 
-// Configuration (the GPIO pins for controlling MUXes must all be from
-// the same bank and are specified as bits so that they can be set together via a Port object)
 struct AdcConfig {
-    // Number of MUX_ADDR pins used by this configuration
-    // (Can be 0 (no muxes) to ADC_MUX_PINS_ADDR_MAX)
+    //! Number of MUX_ADDR pins, can be between 0 (no MUXes) and ADC_MUX_PINS_ADDR_MAX
     U8 num_addr_pins;
-    // Number of MUX_EN pins used by this configuration
+    //! Number of MUX_EN pins, can be between 0 and ADC_MUX_PINS_EN_MAX
     U8 num_en_pins;
-    // Index of the bank of GPIO pins being used
-    // (ignored if num_en_pins & num_addr_pins are 0)
-    Va416x0Mmio::Gpio::Port gpio_port;
-    // Bit for each GPIO pin mapped to a signal to enable a MUX
-    // If a request specifies enable_pin=0, the value in index 0 is used at the pin's bit number
-    // If a request specifies enable_pin=ADC_MUX_PINS_EN_MAX, no enable signal is set
-    // If a request specifies enable_pin >= config.num_en_pins && enable_pin != ADC_MUX_PINS_EN_MAX, FSW asserts
-    // The PBC discussions included deliberation about whether to connect a MUX that didn't need an enable
-    // (because it was always enabled)
-    U8 mux_en_output[ADC_MUX_PINS_EN_MAX];
-    // Bit for each GPIO pin mapped to a signal used for a MUX address/selection
-    // All MUXes must use the same pins for address/selection signals
-    // Value of index 0 is the bit of the pin that sets (1<<0) when selecting the MUX channel
-    // Value of index 1 is the bit of the pin that sets (1<<1) when selecting the MUX channel
-    // Value of index 2 is the bit of the pin that sets (1<<2) when selecting the MUX channel
-    // etc.
+    //! Array of GPIO pins used to enable a MUX. If an ADC request specifies enable_pin=i, the pin
+    //! at index i is used. If a request specifies enable_pin=ADC_MUX_PINS_EN_MAX, no enable signal
+    //! is set
+    Va416x0Mmio::Gpio::Pin mux_en_output[ADC_MUX_PINS_EN_MAX];
+    //! Array of GPIO pins used for MUX address/selection. All MUXes must use the same pins for
+    //! address/selection signals. The pin at index i is the pin that sets 1 << i when selecting
+    //! the MUX channel
     Va416x0Mmio::Gpio::Pin mux_addr_output[ADC_MUX_PINS_ADDR_MAX];
 };
 
-// Declared as final to comply with JPL-C++-Rule32
 class AdcSampler final : public AdcSamplerComponentBase {
     friend class AdcSamplerTester;
 
@@ -87,49 +77,48 @@ class AdcSampler final : public AdcSamplerComponentBase {
     AdcSampler(const char* const compName  //!< The component name
     );
 
-    //! Setup
-    void setup(AdcConfig& config,
-               U32 adc_delay_microseconds,
-               Va416x0Mmio::Timer timer,
-               U8 timer_interrupt_priority,
-               U8 adc_interrupt_priority);
+    //! Component configuration
+    void configure(AdcConfig& config,
+                   U32 adc_delay_microseconds,
+                   Va416x0Mmio::Timer timer,
+                   U8 timer_interrupt_priority,
+                   U8 adc_interrupt_priority);
 
   private:
+    //! Pointer to the ADC configuration
+    AdcConfig* m_config;
     //! ADC read request in progress (set by startRead())
     U32 m_curRequest;
     //! Number of measurements in m_curRequest (set by startRead())
     U32 m_curCnt;
-    //! \brief Pointer to config value from setup()
-    AdcConfig* m_pConfig;
-    //! \brief GPIO port used by pins for controlling MUXes
-    Va416x0Types::Optional<Va416x0Mmio::Gpio::Port> m_muxEnaGpioPort;
-    //! \brief  Bit mask for all pins set for MUXes (enable + address)
+    //! Bit mask for MUX address selection pins
     U32 m_muxPinsMask[Va416x0Mmio::Gpio::NUM_PORTS];
-    //! \brief  Bit mask for all pins set to enable MUXes
-    U32 m_muxEnPinsMask;
-    //! \brief previous value set for pins to control MUXes
+    //! Previous value set for MUX address selection pins
     U32 m_lastPinsValue[Va416x0Mmio::Gpio::NUM_PORTS];
-    //! \brief Number of requests provided by startRead_handler()
+    //! Number of requests provided by startRead_handler()
     U32 m_numReads;
-    //! \brief Pointer to requests provided by startRead_handler()
+    //! Pointer to requests provided by startRead_handler()
     Va416x0::AdcRequests* m_pRequests;
-    //! \brief Pointer to struct to store the results from the m_pRequests
+    //! Pointer to struct to store the results from the m_pRequests
     Va416x0::AdcData* m_pData;
-    //! \brief Index of the current read request
+    //! Index of the current read request
     std::atomic<U32> m_requestIndex;
-    //! \brief Index to store data into when current read completes
+    //! Index to store data into when current read completes
     U32 m_dataIndex;
-    //! \brief The timer delay in timer ticks before triggering the adc conversion
+    //! Timer delay (in timer ticks) before triggering the ADC conversion
     U32 m_adcDelayTicks;
-    //! \brief Timer used to perform the sampling delay
+    //! Timer used to perform the sampling delay
     Va416x0Types::Optional<Va416x0Mmio::Timer> m_timer;
-    //! \brief 100ns delay in clock ticks for the mux disable/enable delay
+    //! Delay (in CPU cycles) after the MUX is enabled or disabled
     U32 m_muxEnaDisDelay;
-    //! \brief Last request which used a mux
+    //! Last request which used a MUX
     U32 m_lastMuxRequest;
 
     //! Starts the next read in the this->m_pRequests list
     void startReadInner();
+
+    //! Calculate the DATAOUT value for the given GPIO port to set the ADDR & EN pins to read a MUX channel
+    U32 calculateGpioPinsValue(U32 request, U32 port);
 
     // ----------------------------------------------------------------------
     // Handler implementations for typed input ports
@@ -153,9 +142,6 @@ class AdcSampler final : public AdcSamplerComponentBase {
                            U8 numReads,
                            Va416x0::AdcRequests& requests,
                            Va416x0::AdcData& data) override;
-
-    //! Calculate the value to set the ADDR & EN pins to read a MUX channel
-    U32 calculateGpioPinsValue(U32 request, U32 port);
 
     //! Handler implementation for getNumDataValues
     U32 getNumDataValues_handler(FwIndexType portNum  //!< The port number

--- a/Va416x0/Drv/AdcSampler/docs/sdd.md
+++ b/Va416x0/Drv/AdcSampler/docs/sdd.md
@@ -1,115 +1,101 @@
 # Va416x0::AdcSampler
 
-Below is the high level design of the AdcSampler's interactions; it's given a list of read requests which it then provides to the ADC peripheral one at a time with the ADC interrupt used to signal it should collect data and program the next request. This design supports:
-1. Sweep reads of non-MUX ADC channels 
+The `AdcSampler` component is given a list of ADC requests which it provides to the ADC peripheral
+one at a time. The component handles the ADC interrupt which signals that it should collect the
+conversion data and program the next request. This design supports:
+
+1. Sweep reads of non-MUX ADC channels
 2. 1 to 16 reads of a single ADC channel (MUX or non-MUX)
-3. Reading external (0 to 7) and internal (8-15) ADC channels  
+3. Reading external (0 to 7) and internal (8-15) ADC channels
 
-Expectations: 
+Expectations:
 1. ADC_DONE interrupt signal is triggered when all conversions requested by CTRL>CONV_CNT value are complete (this is consistent with the programmer guide)
-2. Setting SWEEP_EN=0 and CONV_CNT=15 in the ADC CTRL register will read the channel matching the lowest-bit in CTRL>CHAN_EN 16 times 
+2. Setting SWEEP_EN=0 and CONV_CNT=15 in the ADC CTRL register will read the channel matching the lowest-bit in CTRL>CHAN_EN 16 times
 
-Example contents for an AdcRequest object used to start a read 
-```
-adc_request = {
-    adc_sampler_request(1 << 0 , 15, 0, 0, 0, 0),
-    adc_sampler_request(0xff, 8, 1, 0, 0, 0),
-    adc_sampler_request(1 << 1, 15, 0, 0, 0, 0)
-}
-```
-Example contents of the  AdcData object's array once the reads complete (`A<#>` represents the value read from `AN_IN<#>`)
-```
-{ A0*16, A0, A1, A2, A3, A4, A5, A6, A7, A1*16, ...}
-```
+Each ADC read request is a 4-byte `U32` value with the structure defined below. If an ADC read
+request entry does a sweep read with N channels, N-1 entries following the request must be 0 (e.g.
+`{ {.cnt=3, .is_sweep=1}, {0},{0},{0} ...}`)
 
-The ADC read request entry is defined below (it uses bit packed fields to fit into 4 bytes). If an ADC read request entry does a sweep read with N channels, N-1 entries following must be 0 (.e.g `{ {.cnt=3, .is_sweep=1}, {0},{0},{0} ...}`)
-```
+```c++
 struct AdcEntry{
-    chan_en:     U16 <@ this is a bit mask (to read channel 7, this should be (1<<7))
-    cnt:    U8  (size: 4 bit ) <@ range 0 to 15 supports 1 to 16 samples 
-    enable_pin:  I8  (size: 4 bit ) <@ supports mux_en pins 0 to 15
-    mux_chan:    U8  (size: 5 bit)  <@ supports mux addresses 0 to 31
-    is_mux:      U8  (size: 1 bit ) <@ indicates whether MUX enable & address values should be set
-    is_sweep:    U8  (size: 1 bit ) <@ controls whether N+1 channels are read once or 1 channel is read N+1 times
+    U16 chan_en;    //! 16 bits; Bit mask to select the channel to read, i.e. to read channel 7, this should be 1<<7
+    U8 cnt;         //! 4 bits; Sample count +1 (range 0 to 15 supports 1 to 16 samples)
+    U8 enable_pin;  //! 4 bits; Index of the MUX_EN pin from the ADC config (ignored if is_mux is 0)
+    U8 mux_chan;    //! 5 bits; Channel to select the MUX sample (ignored if is_mux is 0)
+    U8 is_mux;      //! 1 bit; Is this a MUX channel?
+    U8 is_sweep;    //! 1 bit; Is this a sweep read? Controls whether N+1 channels are read once or 1 channel is read N+1 times
 }
 ```
-To assist in bit-packing requests, AdcSampler provides the below static inline function 
-```
-adc_sampler_request(chan_en, cnt, is_sweep, is_mux, enable_pin, mux_chan) 
+
+To assist in bit-packing requests, AdcSampler provides the below static inline function
+```c++
+U32 static inline adc_sampler_request(U16 chan_en, U8 cnt, bool is_sweep, bool is_mux, U8 enable_pin, U8 mux_chan) {
+    // ...
+}
 ```
 
-Setup & configuration will be handled by a public setup method (`AdcSampler::setup()`) which should do the following 
-```
-# 1. Enable ADC digital logic clock in the System Configuration peripherals (bit 13, ADC, of PERIPHERAL_CLK_ENABLES, offset 0x05C)
-# 2. Enable the NVIC entry for the ADC (IRQ #28 and NVIC input #44) 
-# 3. Setup GPIO pin connections for all MUX_EN & MUX_ADDR connections 
-# 4. Set RQ_ENB> ADC_DONE = 1 (and all other bits in the register to 0)
-```
+Configuration is handled by `AdcSampler::configure` which does the following:
+1. Enable the ADC digital logic clock in the System Configuration peripherals (bit 13, ADC, of PERIPHERAL_CLK_ENABLES, offset 0x05C)
+2. Enable the NVIC entry for the ADC interrupt (IRQ #28 and NVIC input #44)
+3. Setup GPIO pin connections for all MUX_EN & MUX_ADDR connections
+4. Set RQ_ENB> ADC_DONE = 1 (and all other bits in the register to 0)
 
-A client (AdcCollector) will begin sampling by calling  startRead (`bool readStart_handler(FwIndexType portNum, U8 num_reads, Scythe::AdcRequests& requests, Scythe::AdcData& data)`) which should do the following 
-```
-# 1. Return FALSE if (this->requestIndex  && this->requestIndex != this->num_reads)
-# 2. Store (by reference) list of read requests in this->requests 
-#       see AdcEntry struct def above 
-# 3. Store (by reference) the data as this->data
-# 4. Set this->requestIndex to 0 
-# 5. Set this->dataIndex to 0 
-# 6. Set this->num_reads to num_reads
-# 7. Call this->startRead()
-# 8. Return TRUE
-```
+A client will begin sampling by calling `startRead` and providing it with a list of ADC read
+requests and a buffer to store the read data. This stores the requests and buffer by reference and
+then calls `startReadInner` which does the following:
+1. Clear out old data by setting the FIFO_CLR >FIFO_CLR bit
+2. If the current request is a MUX read:
+   a. Set the MUX_EN GPIO pin for the request to LO (enabled) and all others to HI (disabled)
+   b. Set MUX_ADDR GPIO pins to reflect the MUX channel for the request
+3. If the current request is a sweep read:
+   a. Write the request channel & CONV_CNT (1) & SWEEP_EN=1 & MANUAL_TRIG values to CTRL register
+4. Otherwise: (this handles the single read & multi-read cases)
+   a. Write the request channel & CONV_CNT (cur_request->cnt) & SWEEP_EN=0 & MANUAL_TRIG values to the CTRL register
 
-The private function `AdcSampler::startRead()` will be invoked by `readStart_handler` and by the interrupt handler and do the following: 
-```
-# 1. Set this->cur_request = &this->requests[this->requestIndex]
-# 2. Assert (this->requestIndex + this->cnt + 1) < this->num_reads
-# 3. Clear old data by setting the FIFO_CLR >FIFO_CLR bit 
-# 4. If this->cur_request->is_mux == TRUE 
-#       a. Set the GPIO pin for this->cur_request->enable_pin to LO (enable) and all others to HI (disable)
-#       b. Set MUX_ADDR pins to reflect this->cur_request->mux_chan
-# 
-# 5. If this->cur_request->is_sweep == TRUE 
-#       a. Write this->cur_request->chan_en & CONV_CNT (1) & SWEEP_EN=1 & MANUAL_TRIG values to CTRL register 
-# 
-# 6. Else:  # (this handles the single read & multi read cases)
-#       a. Write this->cur_request->chan_en & CONV_CNT (cur_request->cnt) & SWEEP_EN=0 & MANUAL_TRIG values to CTRL register 
-```
-
-There will be an interrupt handler (`AdcSampler::adcIrq_handler`) registered (by FPP at compile time) for the ADC interrupt based on the ADC_DONE bit in the IRQ_ENB register. That interrupt handler will do the following: 
+The component registers an interrupt handler (`AdcSampler::adcIrq_handler`) for the ADC interrupt
+based on the ADC_DONE bit in the IRQ_ENB register. The interrupt handler does the following:
 ```
 # 1. If this->cur_request->is_sweep == FALSE && cur_request->cnt > 0
-#       a. set sum = 0 
-#       b. (for n=0; n < (cur_request->cnt+1); n++), 
+#       a. set sum = 0
+#       b. (for n=0; n < (cur_request->cnt+1); n++),
 #           i. read  ADC FIFO register value & add it to sum
 #       c. Store sum into this->data[this->dataIndex]
 #       d. this->dataIndex += 1
-# 2. Else 
+# 2. Else
 #       a. (for n=0; n < (cur_request->cnt+1); n++)
 #           i. Read the ADC FIFO register value & store it into this->data[this->dataIndex + n]
 #       b. this->dataIndex += cur_request->cnt + 1
-# 
+#
 # 3. this->requestIndex += 1
 # 4. If this->requestIndex < this->num_reads, call this->startRead()
 ```
 _MUX_EN is not updated at the end of the read because the next read operation will set the value for the new ADC sample and skipping that update here saves time_
 
-The client will call AdcSampler::startRead() to start a read operation and then poll at some TBD rate (likely no faster than 1 KHz) using `AdcSampler::checkRead()` to see when its requests are complete. 
-```
-# 0. Return BUSY if this->requestIndex == this->num_reads else SUCCESS
-```
+The client calls `startRead` to start a read operation and then polls the `AdcSampler` component at
+some TBD rate (likely no faster than 1 KHz) using `checkRead` to see when the requests are complete.
 
 Advantages:
--  most of the new read operations are triggered via interrupt (high rate)
--  support re-reading the same multiple times 
--  clients can size the list of requests given to AdcSampler to provide flexibility in how frequently the client needs to provide new work
--  All work done in the interrupt context is handled by a single component (limited scope & scope is readily apparent) 
-
-## Performance Information
-
-Performance info is kept under AdcCollector's SDD.
+- Most of the new read operations are triggered via interrupt (high rate)
+- Support re-reading the same channel multiple times
+- Clients can size the list of requests given to AdcSampler to provide flexibility in how frequently the client needs to provide new work
+- All work done in the interrupt context is handled by a single component (limited scope & scope is readily apparent)
 
 ## Usage Examples
-Add usage examples here
+
+Example contents for an `AdcRequest` object used to start a read:
+```c++
+Va416x0::AdcRequests adc_requests[] = {
+    adc_sampler_request(1 << 0 , 15, 0, 0, 0, 0),
+    adc_sampler_request(0xff, 8, 1, 0, 0, 0),
+    adc_sampler_request(1 << 1, 15, 0, 0, 0, 0)
+};
+```
+
+Example contents of the `AdcData` array once the reads complete (`A<#>` represents the value read
+from `AN_IN<#>`):
+```
+{ A0*16, A0, A1, A2, A3, A4, A5, A6, A7, A1*16, ...}
+```
 
 ### Diagrams
 Add diagrams here
@@ -135,24 +121,20 @@ Add component states in the chart below
 Add sequence diagrams here
 
 ## Parameters
-| Name | Description |
-|---|---|
-|---|---|
+
+None.
 
 ## Commands
-| Name | Description |
-|---|---|
-|---|---|
+
+None.
 
 ## Events
-| Name | Description |
-|---|---|
-|---|---|
+
+None.
 
 ## Telemetry
-| Name | Description |
-|---|---|
-|---|---|
+
+None.
 
 ## Unit Tests
 Add unit test descriptions in the chart below

--- a/Va416x0/Drv/AdcSampler/docs/sdd.md
+++ b/Va416x0/Drv/AdcSampler/docs/sdd.md
@@ -12,48 +12,73 @@ Expectations:
 1. ADC_DONE interrupt signal is triggered when all conversions requested by CTRL>CONV_CNT value are complete (this is consistent with the programmer guide)
 2. Setting SWEEP_EN=0 and CONV_CNT=15 in the ADC CTRL register will read the channel matching the lowest-bit in CTRL>CHAN_EN 16 times
 
-Each ADC read request is a 4-byte `U32` value with the structure defined below. If an ADC read
-request entry does a sweep read with N channels, N-1 entries following the request must be 0 (e.g.
-`{ {.cnt=3, .is_sweep=1}, {0},{0},{0} ...}`)
+Example contents for an AdcRequest object used to start a read
+```
+adc_request = {
+    adc_sampler_request(1 << 0 , 15, 0, 0, 0, 0),
+    adc_sampler_request(0xff, 8, 1, 0, 0, 0),
+    adc_sampler_request(1 << 1, 15, 0, 0, 0, 0)
+}
+```
+Example contents of the  AdcData object's array once the reads complete (`A<#>` represents the value read from `AN_IN<#>`)
+```
+{ A0*16, A0, A1, A2, A3, A4, A5, A6, A7, A1*16, ...}
+```
 
-```c++
+The ADC read request entry is defined below (it uses bit packed fields to fit into 4 bytes). If an ADC read request entry does a sweep read with N channels, N-1 entries following must be 0 (.e.g `{ {.cnt=3, .is_sweep=1}, {0},{0},{0} ...}`)
+```
 struct AdcEntry{
-    U16 chan_en;    //! 16 bits; Bit mask to select the channel to read, i.e. to read channel 7, this should be 1<<7
-    U8 cnt;         //! 4 bits; Sample count +1 (range 0 to 15 supports 1 to 16 samples)
-    U8 enable_pin;  //! 4 bits; Index of the MUX_EN pin from the ADC config (ignored if is_mux is 0)
-    U8 mux_chan;    //! 5 bits; Channel to select the MUX sample (ignored if is_mux is 0)
-    U8 is_mux;      //! 1 bit; Is this a MUX channel?
-    U8 is_sweep;    //! 1 bit; Is this a sweep read? Controls whether N+1 channels are read once or 1 channel is read N+1 times
+    chan_en:     U16 <@ this is a bit mask (to read channel 7, this should be (1<<7))
+    cnt:    U8  (size: 4 bit ) <@ range 0 to 15 supports 1 to 16 samples
+    enable_pin:  I8  (size: 4 bit ) <@ supports mux_en pins 0 to 15
+    mux_chan:    U8  (size: 5 bit)  <@ supports mux addresses 0 to 31
+    is_mux:      U8  (size: 1 bit ) <@ indicates whether MUX enable & address values should be set
+    is_sweep:    U8  (size: 1 bit ) <@ controls whether N+1 channels are read once or 1 channel is read N+1 times
 }
 ```
-
 To assist in bit-packing requests, AdcSampler provides the below static inline function
-```c++
-U32 static inline adc_sampler_request(U16 chan_en, U8 cnt, bool is_sweep, bool is_mux, U8 enable_pin, U8 mux_chan) {
-    // ...
-}
+```
+adc_sampler_request(chan_en, cnt, is_sweep, is_mux, enable_pin, mux_chan)
 ```
 
-Configuration is handled by `AdcSampler::configure` which does the following:
-1. Enable the ADC digital logic clock in the System Configuration peripherals (bit 13, ADC, of PERIPHERAL_CLK_ENABLES, offset 0x05C)
-2. Enable the NVIC entry for the ADC interrupt (IRQ #28 and NVIC input #44)
-3. Setup GPIO pin connections for all MUX_EN & MUX_ADDR connections
-4. Set RQ_ENB> ADC_DONE = 1 (and all other bits in the register to 0)
+Setup & configuration will be handled by a public setup method (`AdcSampler::configure()`) which should do the following
+```
+# 1. Enable ADC digital logic clock in the System Configuration peripherals (bit 13, ADC, of PERIPHERAL_CLK_ENABLES, offset 0x05C)
+# 2. Enable the NVIC entry for the ADC (IRQ #28 and NVIC input #44)
+# 3. Setup GPIO pin connections for all MUX_EN & MUX_ADDR connections
+# 4. Set RQ_ENB> ADC_DONE = 1 (and all other bits in the register to 0)
+```
 
-A client will begin sampling by calling `startRead` and providing it with a list of ADC read
-requests and a buffer to store the read data. This stores the requests and buffer by reference and
-then calls `startReadInner` which does the following:
-1. Clear out old data by setting the FIFO_CLR >FIFO_CLR bit
-2. If the current request is a MUX read:
-   a. Set the MUX_EN GPIO pin for the request to LO (enabled) and all others to HI (disabled)
-   b. Set MUX_ADDR GPIO pins to reflect the MUX channel for the request
-3. If the current request is a sweep read:
-   a. Write the request channel & CONV_CNT (1) & SWEEP_EN=1 & MANUAL_TRIG values to CTRL register
-4. Otherwise: (this handles the single read & multi-read cases)
-   a. Write the request channel & CONV_CNT (cur_request->cnt) & SWEEP_EN=0 & MANUAL_TRIG values to the CTRL register
+A client will begin sampling by calling  startRead (`bool readStart_handler(FwIndexType portNum, U8 num_reads, Scythe::AdcRequests& requests, Scythe::AdcData& data)`) which should do the following
+```
+# 1. Return FALSE if (this->requestIndex  && this->requestIndex != this->num_reads)
+# 2. Store (by reference) list of read requests in this->requests
+#       see AdcEntry struct def above
+# 3. Store (by reference) the data as this->data
+# 4. Set this->requestIndex to 0
+# 5. Set this->dataIndex to 0
+# 6. Set this->num_reads to num_reads
+# 7. Call this->startRead()
+# 8. Return TRUE
+```
 
-The component registers an interrupt handler (`AdcSampler::adcIrq_handler`) for the ADC interrupt
-based on the ADC_DONE bit in the IRQ_ENB register. The interrupt handler does the following:
+The private function `AdcSampler::startRead()` will be invoked by `readStart_handler` and by the interrupt handler and do the following:
+```
+# 1. Set this->cur_request = &this->requests[this->requestIndex]
+# 2. Assert (this->requestIndex + this->cnt + 1) < this->num_reads
+# 3. Clear old data by setting the FIFO_CLR >FIFO_CLR bit
+# 4. If this->cur_request->is_mux == TRUE
+#       a. Set the GPIO pin for this->cur_request->enable_pin to LO (enable) and all others to HI (disable)
+#       b. Set MUX_ADDR pins to reflect this->cur_request->mux_chan
+#
+# 5. If this->cur_request->is_sweep == TRUE
+#       a. Write this->cur_request->chan_en & CONV_CNT (1) & SWEEP_EN=1 & MANUAL_TRIG values to CTRL register
+#
+# 6. Else:  # (this handles the single read & multi read cases)
+#       a. Write this->cur_request->chan_en & CONV_CNT (cur_request->cnt) & SWEEP_EN=0 & MANUAL_TRIG values to CTRL register
+```
+
+There will be an interrupt handler (`AdcSampler::adcIrq_handler`) registered (by FPP at compile time) for the ADC interrupt based on the ADC_DONE bit in the IRQ_ENB register. That interrupt handler will do the following:
 ```
 # 1. If this->cur_request->is_sweep == FALSE && cur_request->cnt > 0
 #       a. set sum = 0
@@ -71,31 +96,19 @@ based on the ADC_DONE bit in the IRQ_ENB register. The interrupt handler does th
 ```
 _MUX_EN is not updated at the end of the read because the next read operation will set the value for the new ADC sample and skipping that update here saves time_
 
-The client calls `startRead` to start a read operation and then polls the `AdcSampler` component at
-some TBD rate (likely no faster than 1 KHz) using `checkRead` to see when the requests are complete.
+The client will call AdcSampler::startRead() to start a read operation and then poll at some TBD rate (likely no faster than 1 KHz) using `AdcSampler::checkRead()` to see when its requests are complete.
+```
+# 0. Return BUSY if this->requestIndex == this->num_reads else SUCCESS
+```
 
 Advantages:
-- Most of the new read operations are triggered via interrupt (high rate)
-- Support re-reading the same channel multiple times
-- Clients can size the list of requests given to AdcSampler to provide flexibility in how frequently the client needs to provide new work
-- All work done in the interrupt context is handled by a single component (limited scope & scope is readily apparent)
+-  most of the new read operations are triggered via interrupt (high rate)
+-  support re-reading the same multiple times
+-  clients can size the list of requests given to AdcSampler to provide flexibility in how frequently the client needs to provide new work
+-  All work done in the interrupt context is handled by a single component (limited scope & scope is readily apparent)
 
 ## Usage Examples
-
-Example contents for an `AdcRequest` object used to start a read:
-```c++
-Va416x0::AdcRequests adc_requests[] = {
-    adc_sampler_request(1 << 0 , 15, 0, 0, 0, 0),
-    adc_sampler_request(0xff, 8, 1, 0, 0, 0),
-    adc_sampler_request(1 << 1, 15, 0, 0, 0, 0)
-};
-```
-
-Example contents of the `AdcData` array once the reads complete (`A<#>` represents the value read
-from `AN_IN<#>`):
-```
-{ A0*16, A0, A1, A2, A3, A4, A5, A6, A7, A1*16, ...}
-```
+Add usage examples here
 
 ### Diagrams
 Add diagrams here
@@ -121,20 +134,24 @@ Add component states in the chart below
 Add sequence diagrams here
 
 ## Parameters
-
-None.
+| Name | Description |
+|---|---|
+|---|---|
 
 ## Commands
-
-None.
+| Name | Description |
+|---|---|
+|---|---|
 
 ## Events
-
-None.
+| Name | Description |
+|---|---|
+|---|---|
 
 ## Telemetry
-
-None.
+| Name | Description |
+|---|---|
+|---|---|
 
 ## Unit Tests
 Add unit test descriptions in the chart below

--- a/Va416x0/Drv/AdcSampler/test/ut/AdcSamplerTester.cpp
+++ b/Va416x0/Drv/AdcSampler/test/ut/AdcSamplerTester.cpp
@@ -83,10 +83,6 @@ enum {
     EDGE_STATUS = 0x04C,
 };
 
-static U32 read_gpio_dataout(U32 gpio_port) {
-    return Va416x0Mmio::Amba::read_u32(GPIO_ADDRESS | (gpio_port * GPIO_PORT_STRIDE) | DATAOUT);
-}
-
 // ----------------------------------------------------------------------
 // Construction and destruction
 // ----------------------------------------------------------------------
@@ -103,15 +99,21 @@ AdcSamplerTester ::~AdcSamplerTester() {}
 // Tests
 // ----------------------------------------------------------------------
 
+Va416x0Mmio::Gpio::Pin mux_en_pins[] = {Va416x0Mmio::Gpio::PORTA[1], Va416x0Mmio::Gpio::PORTA[5],
+                                        Va416x0Mmio::Gpio::PORTA[3]};
+Va416x0Mmio::Gpio::Pin mux_addr_pins[] = {Va416x0Mmio::Gpio::PORTB[0], Va416x0Mmio::Gpio::PORTB[1],
+                                          Va416x0Mmio::Gpio::PORTC[2], Va416x0Mmio::Gpio::PORTD[3],
+                                          Va416x0Mmio::Gpio::PORTE[4]};
 Va416x0::AdcConfig three_mux_pin_config = {
-    5,
-    3,
-    Va416x0Mmio::Gpio::PORTA,
-    {1, 5, 3, 0, 0, 0, 0, 0, 0, 0},
-    // Address Pins
-    {Va416x0Mmio::Gpio::Pin(Va416x0Mmio::Gpio::PORTB, 0), Va416x0Mmio::Gpio::Pin(Va416x0Mmio::Gpio::PORTB, 1),
-     Va416x0Mmio::Gpio::Pin(Va416x0Mmio::Gpio::PORTC, 2), Va416x0Mmio::Gpio::Pin(Va416x0Mmio::Gpio::PORTD, 3),
-     Va416x0Mmio::Gpio::Pin(Va416x0Mmio::Gpio::PORTE, 4)}};
+    mux_en_pins,
+    FW_NUM_ARRAY_ELEMENTS(mux_en_pins),
+    mux_addr_pins,
+    FW_NUM_ARRAY_ELEMENTS(mux_addr_pins),
+    20,
+    Va416x0Mmio::Timer(18),
+    Va416x0Mmio::Nvic::PRIORITY_GROUP_5,
+    Va416x0Mmio::Nvic::PRIORITY_GROUP_5,
+};
 
 Va416x0::AdcRequests three_mux_pin_config_requests = {
     // AV 1
@@ -165,28 +167,26 @@ void AdcSamplerTester ::testStartReadMuxEnableDisableDelay() {
         gpioPort.write_irq_enb(0);
     }
 
-    this->component.setup(three_mux_pin_config, 20, Va416x0Mmio::Timer(18), Va416x0Mmio::Nvic::PRIORITY_GROUP_5,
-                          Va416x0Mmio::Nvic::PRIORITY_GROUP_5);
+    this->component.configure(three_mux_pin_config);
     printf("Testing MUX index 0, pin 1, port A\n");
     {
-        // Get the mux enable gpio port
-        Va416x0Mmio::Gpio::Port gpioPort = Va416x0Mmio::Gpio::Port(three_mux_pin_config.gpio_port);
         // Check the dummy value is set
         EXPECT_TRUE(REQ_GET_MUX_ENABLE(this->component.m_lastMuxRequest) == ADC_MUX_PINS_EN_MAX);
 
         this->component.startRead_handlerBase(0, 8, three_mux_pin_config_requests, this->m_data);
         EXPECT_TRUE(this->component.m_requestIndex == 0);
 
-        // Read in the port pin values
-        U32 pin_values = read_gpio_dataout(three_mux_pin_config.gpio_port.get_gpio_port());
-        printf("pin values 0x%08x\n", pin_values);
         // For the current request get the enable channel pin, in this case request index 0 uses mux enable 0
         U32 req_mux_enable = REQ_GET_MUX_ENABLE(this->component.m_curRequest);
         printf("Mux enable pin %d\n", req_mux_enable);
         // Confirm that only a single mux is enabled (0) and all others are 1
-        EXPECT_TRUE((pin_values & (1 << three_mux_pin_config.mux_en_output[req_mux_enable])) == 0);
-        EXPECT_TRUE((pin_values & (1 << 5)));
-        EXPECT_TRUE((pin_values & (1 << 3)));
+        for (U8 i = 0; i < three_mux_pin_config.muxEnPinCount; i++) {
+            if (i == req_mux_enable) {
+                EXPECT_TRUE(three_mux_pin_config.muxEnPins[i].in() == Fw::Logic::LOW);
+            } else {
+                EXPECT_TRUE(three_mux_pin_config.muxEnPins[i].in() == Fw::Logic::HIGH);
+            }
+        }
         // Confirm the requests match as expected
         EXPECT_TRUE(this->component.m_curRequest == three_mux_pin_config_requests[this->component.m_requestIndex]);
         // Confirm the last mux request changed
@@ -199,18 +199,17 @@ void AdcSamplerTester ::testStartReadMuxEnableDisableDelay() {
     EXPECT_TRUE(this->component.m_requestIndex == 1);
     this->component.startReadInner();
     {
-        // Get the mux enable gpio port
-        Va416x0Mmio::Gpio::Port gpioPort = Va416x0Mmio::Gpio::Port(three_mux_pin_config.gpio_port);
-        // Read in the port pin values
-        U32 pin_values = read_gpio_dataout(three_mux_pin_config.gpio_port.get_gpio_port());
-        printf("pin values 0x%08x\n", pin_values);
         // For the current request get the enable channel pin, in this case request index 0 uses mux enable 0
         U32 req_mux_enable = REQ_GET_MUX_ENABLE(this->component.m_curRequest);
         printf("Mux enable pin %d\n", req_mux_enable);
         // Confirm that only a single mux is enabled (0) and all others are 1
-        EXPECT_TRUE((pin_values & (1 << three_mux_pin_config.mux_en_output[req_mux_enable])) == 0);
-        EXPECT_TRUE((pin_values & (1 << 1)));
-        EXPECT_TRUE((pin_values & (1 << 3)));
+        for (U8 i = 0; i < three_mux_pin_config.muxEnPinCount; i++) {
+            if (i == req_mux_enable) {
+                EXPECT_TRUE(three_mux_pin_config.muxEnPins[i].in() == Fw::Logic::LOW);
+            } else {
+                EXPECT_TRUE(three_mux_pin_config.muxEnPins[i].in() == Fw::Logic::HIGH);
+            }
+        }
         // Confirm the requests match as expected
         EXPECT_TRUE(this->component.m_curRequest == three_mux_pin_config_requests[this->component.m_requestIndex]);
         // Confirm the last mux request changed
@@ -223,18 +222,17 @@ void AdcSamplerTester ::testStartReadMuxEnableDisableDelay() {
     EXPECT_TRUE(this->component.m_requestIndex == 2);
     this->component.startReadInner();
     {
-        // Get the mux enable gpio port
-        Va416x0Mmio::Gpio::Port gpioPort = Va416x0Mmio::Gpio::Port(three_mux_pin_config.gpio_port);
-        // Read in the port pin values
-        U32 pin_values = read_gpio_dataout(three_mux_pin_config.gpio_port.get_gpio_port());
-        printf("pin values 0x%08x\n", pin_values);
         // For the current request get the enable channel pin, in this case request index 0 uses mux enable 0
         U32 req_mux_enable = REQ_GET_MUX_ENABLE(this->component.m_curRequest);
         printf("Mux enable pin %d\n", req_mux_enable);
         // Confirm that only a single mux is enabled (0) and all others are 1
-        EXPECT_TRUE((pin_values & (1 << three_mux_pin_config.mux_en_output[req_mux_enable])) == 0);
-        EXPECT_TRUE((pin_values & (1 << 1)));
-        EXPECT_TRUE((pin_values & (1 << 5)));
+        for (U8 i = 0; i < three_mux_pin_config.muxEnPinCount; i++) {
+            if (i == req_mux_enable) {
+                EXPECT_TRUE(three_mux_pin_config.muxEnPins[i].in() == Fw::Logic::LOW);
+            } else {
+                EXPECT_TRUE(three_mux_pin_config.muxEnPins[i].in() == Fw::Logic::HIGH);
+            }
+        }
         // Confirm the requests match as expected
         EXPECT_TRUE(this->component.m_curRequest == three_mux_pin_config_requests[this->component.m_requestIndex]);
         // Confirm the last mux request changed
@@ -258,22 +256,13 @@ void AdcSamplerTester ::testStartReadGpioConfiguration() {
         gpioPort.write_irq_enb(0);
     }
 
-    this->component.setup(three_mux_pin_config, 20, Va416x0Mmio::Timer(18), Va416x0Mmio::Nvic::PRIORITY_GROUP_5,
-                          Va416x0Mmio::Nvic::PRIORITY_GROUP_5);
+    this->component.configure(three_mux_pin_config);
     printf("Testing address indexing\n");
     {
-        for (U32 index = 0; index < three_mux_pin_config.num_en_pins; index++) {
-            Va416x0Mmio::Gpio::Port gpioPort =
-                Va416x0Mmio::Gpio::Port(three_mux_pin_config.mux_addr_output[index].getGpioPortNumber());
-            gpioPort.write_dataout(0);
-        }
         this->component.startRead_handlerBase(0, 8, three_mux_pin_config_requests, this->m_data);
         EXPECT_TRUE(this->component.m_requestIndex == 0);
-        for (U32 index = 0; index < three_mux_pin_config.num_en_pins; index++) {
-            U32 pin_number = three_mux_pin_config.mux_addr_output[index].getPinNumber();
-
-            EXPECT_TRUE(read_gpio_dataout(three_mux_pin_config.mux_addr_output[index].getGpioPortNumber()) &
-                        static_cast<U32>(1 << pin_number));
+        for (U32 i = 0; i < three_mux_pin_config.muxAddrPinCount; i++) {
+            EXPECT_TRUE(three_mux_pin_config.muxAddrPins[i].in() == Fw::Logic::HIGH);
         }
     }
 }

--- a/Va416x0/Mmio/Gpio/CMakeLists.txt
+++ b/Va416x0/Mmio/Gpio/CMakeLists.txt
@@ -14,10 +14,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-register_fprime_library(
-    SOURCES
+if (FPRIME_PLATFORM STREQUAL "va416x0-baremetal")
+    set(GPIO_SOURCES
         Pin.cpp
         Port.cpp
+    )
+else()
+    set(GPIO_SOURCES
+        Pin.cpp
+        PortStubs.cpp
+    )
+endif()
+
+register_fprime_library(
+    SOURCES
+        ${GPIO_SOURCES}
     HEADERS
         Pin.hpp
         Port.hpp

--- a/Va416x0/Mmio/Gpio/PortStubs.cpp
+++ b/Va416x0/Mmio/Gpio/PortStubs.cpp
@@ -1,0 +1,312 @@
+// Copyright 2025 California Institute of Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "Fw/Types/Assert.hpp"
+#include "Os/Mutex.hpp"
+#include "Port.hpp"
+#include "Va416x0/Mmio/Amba/Amba.hpp"
+#include "Va416x0/Mmio/Gpio/Pin.hpp"
+#include "Va416x0/Mmio/SysConfig/SysConfig.hpp"
+
+#include <map>
+#include <tuple>
+
+// FIXME: this is an incomplete first-pass at GPIO stubs, these will need to be expanded to support
+// additional features
+
+namespace Va416x0Mmio {
+namespace Gpio {
+
+// Track pin states
+static std::map<std::tuple<U8, U8>, Fw::Logic> pinStates;
+
+constexpr U32 GPIO_ADDRESS = 0x40012000;
+
+Os::Mutex Port::config_locks[NUM_PORTS];
+
+enum {
+    GPIO_PORT_STRIDE = 0x400,
+    GPIO_EXCEPTION_BASE = Va416x0Types::ExceptionNumber::INTERRUPT_PORTA_0,
+    GPIO_EXCEPTION_STRIDE = 16,
+    GPIO_CASCADE_BASE = 0,
+    GPIO_CASCADE_STRIDE = 16,
+
+    DATAIN = 0x000,
+    DATAINRAW = 0x004,
+    DATAOUT = 0x008,
+    DATAOUTRAW = 0x00C,
+    SETOUT = 0x010,
+    CLROUT = 0x014,
+    TOGOUT = 0x018,
+    DATAMASK = 0x01C,
+    DIR = 0x020,
+    PULSE = 0x024,
+    PULSEBASE = 0x028,
+    DELAY1 = 0x02C,
+    DELAY2 = 0x030,
+    IRQ_SEN = 0x034,
+    IRQ_EDGE = 0x038,
+    IRQ_EVT = 0x03C,
+    IRQ_ENB = 0x040,
+    IRQ_RAW = 0x044,
+    IRQ_END = 0x048,
+    EDGE_STATUS = 0x04C,
+};
+
+U32 Port::read(U32 offset) const {
+    // FIXME: Should we pre-calculate the base address?
+    return Amba::read_u32(GPIO_ADDRESS | (gpio_port * GPIO_PORT_STRIDE) | offset);
+}
+
+void Port::write(U32 offset, U32 value) const {
+    // FIXME: Should we pre-calculate the base address?
+    Amba::write_u32(GPIO_ADDRESS | (gpio_port * GPIO_PORT_STRIDE) | offset, value);
+}
+
+Os::Mutex& Port::get_gpio_config_lock() const {
+    FW_ASSERT(gpio_port < NUM_PORTS, gpio_port);
+    return config_locks[gpio_port];
+}
+
+void Port::configure_pins(U32 selected_pins,
+                          U32 pins_direction,
+                          U32 pins_pulse,
+                          U32 pins_pulsebase,
+                          U32 pins_delay1,
+                          U32 pins_delay2,
+                          U32 pins_irq_sen,
+                          U32 pins_irq_edge,
+                          U32 pins_irq_evt,
+                          U32 pins_irq_enb) const {}
+
+U32 Port::read_datain() const {
+    // FIXME: add masking support
+    return read_datainraw();
+}
+
+void Port::write_datain(U32 value) const {
+    // FIXME: add masking support
+    write_datainraw(value);
+}
+
+U32 Port::read_datainraw() const {
+    U32 value = 0;
+    for (U32 i = 0; i < MAX_PINS_PER_PORT; i++) {
+        auto pin = std::make_tuple(gpio_port, i);
+        if (pinStates.count(pin)) {
+            value |= (pinStates[pin] << i);
+        }
+    }
+    return value;
+}
+
+void Port::write_datainraw(U32 value) const {
+    // Write-only register
+}
+
+U32 Port::read_dataout() const {
+    // FIXME: add masking support
+    return read_dataoutraw();
+}
+
+void Port::write_dataout(U32 value) const {
+    // FIXME: add masking support
+    write_dataoutraw(value);
+}
+
+U32 Port::read_dataoutraw() const {
+    // FIXME: treats DATAIN and DATAOUT as the same
+    return read_datainraw();
+}
+
+void Port::write_dataoutraw(U32 value) const {
+    for (U32 i = 0; i < MAX_PINS_PER_PORT; i++) {
+        auto pin = std::make_tuple(gpio_port, i);
+        auto state = (value & (1 << i)) ? Fw::Logic::HIGH : Fw::Logic::LOW;
+        pinStates[pin] = state;
+    }
+}
+
+U32 Port::read_setout() const {
+    return read(SETOUT);
+}
+
+void Port::write_setout(U32 value) const {
+    for (U32 i = 0; i < MAX_PINS_PER_PORT; i++) {
+        if (value & (1 << i)) {
+            auto pin = std::make_tuple(gpio_port, i);
+            pinStates[pin] = Fw::Logic::HIGH;
+        }
+    }
+}
+
+U32 Port::read_clrout() const {
+    return read(CLROUT);
+}
+
+void Port::write_clrout(U32 value) const {
+    for (U32 i = 0; i < MAX_PINS_PER_PORT; i++) {
+        if (value & (1 << i)) {
+            auto pin = std::make_tuple(gpio_port, i);
+            pinStates[pin] = Fw::Logic::LOW;
+        }
+    }
+}
+
+U32 Port::read_togout() const {
+    return read(TOGOUT);
+}
+
+void Port::write_togout(U32 value) const {
+    write(TOGOUT, value);
+}
+
+U32 Port::read_datamask() const {
+    return read(DATAMASK);
+}
+
+void Port::write_datamask(U32 value) const {
+    write(DATAMASK, value);
+}
+
+U32 Port::read_dir() const {
+    return read(DIR);
+}
+
+void Port::write_dir(U32 value) const {
+    write(DIR, value);
+}
+
+U32 Port::read_pulse() const {
+    return read(PULSE);
+}
+
+void Port::write_pulse(U32 value) const {
+    write(PULSE, value);
+}
+
+U32 Port::read_pulsebase() const {
+    return read(PULSEBASE);
+}
+
+void Port::write_pulsebase(U32 value) const {
+    write(PULSEBASE, value);
+}
+
+U32 Port::read_delay1() const {
+    return read(DELAY1);
+}
+
+void Port::write_delay1(U32 value) const {
+    write(DELAY1, value);
+}
+
+U32 Port::read_delay2() const {
+    return read(DELAY2);
+}
+
+void Port::write_delay2(U32 value) const {
+    write(DELAY2, value);
+}
+
+U32 Port::read_irq_sen() const {
+    return read(IRQ_SEN);
+}
+
+void Port::write_irq_sen(U32 value) const {
+    write(IRQ_SEN, value);
+}
+
+U32 Port::read_irq_edge() const {
+    return read(IRQ_EDGE);
+}
+
+void Port::write_irq_edge(U32 value) const {
+    write(IRQ_EDGE, value);
+}
+
+U32 Port::read_irq_evt() const {
+    return read(IRQ_EVT);
+}
+
+void Port::write_irq_evt(U32 value) const {
+    write(IRQ_EVT, value);
+}
+
+U32 Port::read_irq_enb() const {
+    return read(IRQ_ENB);
+}
+
+void Port::write_irq_enb(U32 value) const {
+    write(IRQ_ENB, value);
+}
+
+U32 Port::read_irq_raw() const {
+    return read(IRQ_RAW);
+}
+
+void Port::write_irq_raw(U32 value) const {
+    write(IRQ_RAW, value);
+}
+
+U32 Port::read_irq_end() const {
+    return read(IRQ_END);
+}
+
+void Port::write_irq_end(U32 value) const {
+    write(IRQ_END, value);
+}
+
+U32 Port::read_edge_status() const {
+    return read(EDGE_STATUS);
+}
+
+void Port::write_edge_status(U32 value) const {
+    write(EDGE_STATUS, value);
+}
+
+Va416x0Types::ExceptionNumber::T Port::get_base_exception() const {
+    // There are no interrupts on PORTG, so this must be a coding defect.
+    FW_ASSERT(gpio_port < PORTG.gpio_port, gpio_port);
+
+    return Va416x0Types::ExceptionNumber::T(GPIO_EXCEPTION_BASE + GPIO_EXCEPTION_STRIDE * gpio_port);
+}
+
+U8 Port::get_base_cascade_index() const {
+    // Ports F and G cannot be used for cascades, so this must be a coding defect.
+    FW_ASSERT(gpio_port <= PORTE.gpio_port, gpio_port);
+
+    return GPIO_CASCADE_BASE + GPIO_CASCADE_STRIDE * gpio_port;
+}
+
+Port::operator SysConfig::ClockedPeripheral() const {
+    return SysConfig::ClockedPeripheral(SysConfig::ClockedPeripheral::PORTA_INDEX + gpio_port);
+}
+
+bool Port::operator==(const Port& other) const {
+    return gpio_port == other.gpio_port;
+}
+
+bool Port::operator!=(const Port& other) const {
+    return !(*this == other);
+}
+
+U32 Port::get_gpio_port() const {
+    return gpio_port;
+}
+
+}  // namespace Gpio
+}  // namespace Va416x0Mmio


### PR DESCRIPTION
Previously, `AdcSampler` assumed all MUX_EN pins were on the same GPIO port. This update generalizes the component so that MUX_EN pins can span multiple ports. When a MUX request is handled, the previous MUX_EN pin is disabled (if one existed) and then the next MUX_EN pin is enabled. This also updates the format of the `AdcConfig` struct and renames the `setup` function to `configure` to align with F-Prime style.

These updates broke the UTs so this also includes a fix to those. Since the GPIO pins are accessed in a new way, the previous approach (looking at the Amba backend) is not feasible, so this includes a basic set of GPIO stubs to help with testing.

Note that almost all of the updates to the SDD are from my editor trimming trailing whitespace so ignoring that will make the diff more manageable.