### PR TITLE
Update CMAKE to detect & reject using an unaligned libc 

### DIFF
--- a/cmake/toolchain/check_library_unaligned.cmake
+++ b/cmake/toolchain/check_library_unaligned.cmake
@@ -26,10 +26,13 @@ if (EXISTS "${LIBC_PATH}")
     string(REGEX MATCH "Tag_CPU_unaligned_access: ([^\n]+)" UNALIGNED_MATCH "${READELF_OUTPUT}")
 
     if (UNALIGNED_MATCH)
+        set(UNALIGNED_VALUE "${CMAKE_MATCH_1}")
+        string(STRIP "${UNALIGNED_VALUE}" UNALIGNED_VALUE)
+    endif()
+
+    if (UNALIGNED_MATCH AND NOT UNALIGNED_VALUE STREQUAL "None")
         string(SUBSTRING "${READELF_OUTPUT}" 0 1000 READELF_OUTPUT_TRUNC)
         message(INFO "${READELF_OUTPUT_TRUNC}")
-        set(UNALIGNED_VALUE "${CMAKE_MATCH_1}")
-        # FIXME: changed fatal to a log message
         message(FATAL_ERROR 
             "Selected C library was built with unaligned access support: ${UNALIGNED_VALUE}n"
             "Library: ${LIBC_PATH}\n"

--- a/cmake/toolchain/check_library_unaligned.cmake
+++ b/cmake/toolchain/check_library_unaligned.cmake
@@ -33,9 +33,9 @@ if (EXISTS "${LIBC_PATH}")
     # If Tag_CPU_unaligned_access was present & not None, report the error and quit
     if (UNALIGNED_MATCH AND NOT UNALIGNED_VALUE STREQUAL "None")
         string(SUBSTRING "${READELF_OUTPUT}" 0 1000 READELF_OUTPUT_TRUNC)
-        message(INFO "${READELF_OUTPUT_TRUNC}")
+        message(VERBOSE "${READELF_OUTPUT_TRUNC}")
         message(FATAL_ERROR 
-            "Selected C library was built with unaligned access support: ${UNALIGNED_VALUE}n"
+            "Selected C library was built with unaligned access support: ${UNALIGNED_VALUE}\n"
             "Library: ${LIBC_PATH}\n"
             "fprime-vorago does not allow unaligned memory accesses.\n"
             "A library built with -mno-unaligned-access is required.\n")

--- a/cmake/toolchain/check_library_unaligned.cmake
+++ b/cmake/toolchain/check_library_unaligned.cmake
@@ -1,0 +1,41 @@
+# Check that the selected C library was not built with unaligned access support
+# This is critical because CCR_UNALIGN_TRP is set in fprime-vorago/Va416x0/Svc/VectorTable/
+
+# Build compiler flags string
+separate_arguments(C_FLAGS_LIST UNIX_COMMAND "${CMAKE_C_FLAGS}")
+
+# Find the C library that will be linked
+execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${C_FLAGS_LIST} -print-file-name=libc.a
+    OUTPUT_VARIABLE LIBC_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+if (EXISTS "${LIBC_PATH}")
+    message(STATUS "Checking library unaligned access support: ${LIBC_PATH}")
+
+    # Use readelf to check the ARM attributes
+    execute_process(
+        COMMAND arm-none-eabi-readelf -A "${LIBC_PATH}"
+        OUTPUT_VARIABLE READELF_OUTPUT
+        ERROR_QUIET
+    )
+
+    # Check if Tag_CPU_unaligned_access is present
+    string(REGEX MATCH "Tag_CPU_unaligned_access: ([^\n]+)" UNALIGNED_MATCH "${READELF_OUTPUT}")
+
+    if (UNALIGNED_MATCH)
+        set(UNALIGNED_VALUE "${CMAKE_MATCH_1}")
+        # FIXME: changed fatal to a log message
+        message(FATAL_ERROR 
+            "Selected C library was built with unaligned access support: ${UNALIGNED_VALUE}n"
+            "Library: ${LIBC_PATH}\n"
+            "fprime-vorago does not allow unaligned memory accesses.\n"
+            "A library built with -mno-unaligned-access is required.\n")
+    else()
+        message(STATUS "Library unaligned access check: OK (no unaligned access support detected)")
+    endif()
+else()
+    message(WARNING "Could not find C library to check unaligned access support")
+endif()

--- a/cmake/toolchain/check_library_unaligned.cmake
+++ b/cmake/toolchain/check_library_unaligned.cmake
@@ -26,6 +26,8 @@ if (EXISTS "${LIBC_PATH}")
     string(REGEX MATCH "Tag_CPU_unaligned_access: ([^\n]+)" UNALIGNED_MATCH "${READELF_OUTPUT}")
 
     if (UNALIGNED_MATCH)
+        string(SUBSTRING "${READELF_OUTPUT}" 0 1000 READELF_OUTPUT_TRUNC)
+        message(INFO "${READELF_OUTPUT_TRUNC}")
         set(UNALIGNED_VALUE "${CMAKE_MATCH_1}")
         # FIXME: changed fatal to a log message
         message(FATAL_ERROR 

--- a/cmake/toolchain/check_library_unaligned.cmake
+++ b/cmake/toolchain/check_library_unaligned.cmake
@@ -30,6 +30,7 @@ if (EXISTS "${LIBC_PATH}")
         string(STRIP "${UNALIGNED_VALUE}" UNALIGNED_VALUE)
     endif()
 
+    # If Tag_CPU_unaligned_access was present & not None, report the error and quit
     if (UNALIGNED_MATCH AND NOT UNALIGNED_VALUE STREQUAL "None")
         string(SUBSTRING "${READELF_OUTPUT}" 0 1000 READELF_OUTPUT_TRUNC)
         message(INFO "${READELF_OUTPUT_TRUNC}")

--- a/cmake/toolchain/va416x0-baremetal.cmake
+++ b/cmake/toolchain/va416x0-baremetal.cmake
@@ -150,7 +150,7 @@ make_directory("${BUILD_INFO_AC_DIR}")
 # FIXME - Related F' ticket: https://github.com/nasa/fprime/issues/4032
 make_directory("${CMAKE_BINARY_DIR}/.fprime-build-dir")
 
-
+# Verify that the libc selected was built without unlaligned-access enabled 
 include("${CMAKE_CURRENT_LIST_DIR}/check_library_unaligned.cmake")
 
 

--- a/cmake/toolchain/va416x0-baremetal.cmake
+++ b/cmake/toolchain/va416x0-baremetal.cmake
@@ -150,6 +150,10 @@ make_directory("${BUILD_INFO_AC_DIR}")
 # FIXME - Related F' ticket: https://github.com/nasa/fprime/issues/4032
 make_directory("${CMAKE_BINARY_DIR}/.fprime-build-dir")
 
+
+include("${CMAKE_CURRENT_LIST_DIR}/check_library_unaligned.cmake")
+
+
 # Call this in the deployment CMakeLists after register_fprime_deployment to
 # ensure App.hex is generated in addition to App.elf file
 # register_with_bsp("${PROJECT_NAME}")


### PR DESCRIPTION
CCR_UNALIGN_TRP is set to 1  in fprime-vorago/Va416x0/Svc/VectorTable/ - so using any libc version that allows unaligned memory accesses can (but is not guaranteed to) result in a usage fault exception due to unaligned memory access. 

This PR should not be merged until after https://github.com/fprime-community/llvm-vorago-arm-toolchain/pull/10  (added strict alignment versions of libc) 
