### PR TITLE
Updated AdcSampler to fix how muxEnPin is checked

### DIFF
--- a/Va416x0/Drv/AdcSampler/AdcSampler.cpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.cpp
@@ -254,17 +254,21 @@ void AdcSampler::startReadInner() {
         if (muxEnIndex != previousMuxEnIndex) {
             // Disable the previous MUX_EN pin, unless the previous pin index is the dummy value
             // which indicates that no MUX request has been received yet
-            if (previousMuxEnIndex < ADC_MUX_PINS_EN_MAX) {
+            if (previousMuxEnIndex != ADC_MUX_PINS_EN_MAX) {
+                FW_ASSERT(previousMuxEnIndex < this->m_config->muxEnPinCount, previousMuxEnIndex, this->m_curRequest,
+                          this->m_config->muxEnPinCount);
                 this->m_config->muxEnPins[previousMuxEnIndex].out(Fw::Logic::HIGH);
                 // Delay after disabling the previous MUX_EN pin
                 Va416x0Mmio::Amba::memory_barrier();
                 Va416x0Mmio::Cpu::delay_cycles(this->m_muxEnaDisDelay);
             }
 
-            // Enable the new MUX_EN pin
-            FW_ASSERT(muxEnIndex < this->m_config->muxEnPinCount, muxEnIndex, this->m_curRequest,
-                      this->m_config->muxEnPinCount);
-            this->m_config->muxEnPins[muxEnIndex].out(Fw::Logic::LOW);
+            // Enable the new MUX_EN pin (unless the new one is the dummy value)
+            if (muxEnIndex != ADC_MUX_PINS_EN_MAX) {
+                FW_ASSERT(muxEnIndex < this->m_config->muxEnPinCount, muxEnIndex, this->m_curRequest,
+                          this->m_config->muxEnPinCount);
+                this->m_config->muxEnPins[muxEnIndex].out(Fw::Logic::LOW);
+            }
         }
 
         // Calculate the values for the MUX address selection pins
@@ -314,9 +318,7 @@ U32 AdcSampler::calculateGpioPinsValue(U32 request, U32 port_number) {
     U8 numAddrPins = this->m_config->muxAddrPinCount;
     U8 numEnPins = this->m_config->muxEnPinCount;
     U8 mux_chan = REQ_GET_MUX_CHAN(request);
-    U8 mux_en_index = REQ_GET_MUX_ENABLE(request);
     FW_ASSERT(mux_chan < (1 << numAddrPins), mux_chan, numAddrPins);
-    FW_ASSERT(mux_en_index < numEnPins, mux_en_index, numEnPins);
 
     // The address pins should be set as a binary translation of the mux channel
     // where HI=1 and LO=0 (selecting Chan31 = 0b11111, selecting Chan0=0b0000)

--- a/Va416x0/Drv/AdcSampler/AdcSampler.cpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.cpp
@@ -255,8 +255,8 @@ void AdcSampler::startReadInner() {
             // Disable the previous MUX_EN pin, unless the previous pin index is the dummy value
             // which indicates that no MUX request has been received yet
             if (previousMuxEnIndex != ADC_MUX_PINS_EN_MAX) {
-                FW_ASSERT(previousMuxEnIndex < this->m_config->muxEnPinCount, previousMuxEnIndex, this->m_curRequest,
-                          this->m_config->muxEnPinCount);
+                FW_ASSERT(previousMuxEnIndex < this->m_config->muxEnPinCount, previousMuxEnIndex,
+                          this->m_lastMuxRequest, this->m_config->muxEnPinCount);
                 this->m_config->muxEnPins[previousMuxEnIndex].out(Fw::Logic::HIGH);
                 // Delay after disabling the previous MUX_EN pin
                 Va416x0Mmio::Amba::memory_barrier();

--- a/Va416x0/Drv/AdcSampler/AdcSampler.cpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.cpp
@@ -316,7 +316,6 @@ void AdcSampler::startReadInner() {
 U32 AdcSampler::calculateGpioPinsValue(U32 request, U32 port_number) {
     U32 pin_values = 0;
     U8 numAddrPins = this->m_config->muxAddrPinCount;
-    U8 numEnPins = this->m_config->muxEnPinCount;
     U8 mux_chan = REQ_GET_MUX_CHAN(request);
     FW_ASSERT(mux_chan < (1 << numAddrPins), mux_chan, numAddrPins);
 


### PR DESCRIPTION
The assert check for REQ_GET_MUX_ENABLE(request) in AdcSampler::calculateGpioPinsValue() was failing (`EventSeverity.FATAL,Assert in file 0xE841BFEB, line 319: 10 0`) because it wasn't handling ADC_MUX_PINS_EN_MAX. The assert  should have been checking `mux_en_index < numEnPins || mux_en_index == ADC_MUX_PINS_EN_MAX` - but that function doesn't use the mux en index so the assert was removed entirely. 

AdcSampler::startReadInner() (which does use the mux enable pin index)  was updated to check that muxEnIndex was not ADC_MUX_PINS_EN_MAX before asserting on its value and using the pin index. 