### PR TITLE
Add AdcSampler configuration to toggle MUX_EN inversion

### DIFF
--- a/Va416x0/Drv/AdcSampler/AdcSampler.cpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.cpp
@@ -134,8 +134,9 @@ void AdcSampler::configure(const AdcConfig& config) {
     }
     for (U32 i = 0; i < config.muxEnPinCount; i++) {
         auto pin = &config.muxEnPins[i];
-        // Default enable pins to HIGH (MUX disabled)
-        pin->out(Fw::Logic::HIGH);
+        // Default MUX enable pins to be disabled
+        auto pinDisabled = config.invertMuxEn ? Fw::Logic::HIGH : Fw::Logic::LOW;
+        pin->out(pinDisabled);
         pin->configure_as_gpio(Fw::Direction::OUT);
     }
 
@@ -255,7 +256,8 @@ void AdcSampler::startReadInner() {
             // Disable the previous MUX_EN pin, unless the previous pin index is the dummy value
             // which indicates that no MUX request has been received yet
             if (previousMuxEnIndex < ADC_MUX_PINS_EN_MAX) {
-                this->m_config->muxEnPins[previousMuxEnIndex].out(Fw::Logic::HIGH);
+                auto pinDisabled = this->m_config->invertMuxEn ? Fw::Logic::HIGH : Fw::Logic::LOW;
+                this->m_config->muxEnPins[previousMuxEnIndex].out(pinDisabled);
                 // Delay after disabling the previous MUX_EN pin
                 Va416x0Mmio::Amba::memory_barrier();
                 Va416x0Mmio::Cpu::delay_cycles(this->m_muxEnaDisDelay);
@@ -264,7 +266,8 @@ void AdcSampler::startReadInner() {
             // Enable the new MUX_EN pin
             FW_ASSERT(muxEnIndex < this->m_config->muxEnPinCount, muxEnIndex, this->m_curRequest,
                       this->m_config->muxEnPinCount);
-            this->m_config->muxEnPins[muxEnIndex].out(Fw::Logic::LOW);
+            auto pinEnabled = this->m_config->invertMuxEn ? Fw::Logic::LOW : Fw::Logic::HIGH;
+            this->m_config->muxEnPins[muxEnIndex].out(pinEnabled);
         }
 
         // Calculate the values for the MUX address selection pins

--- a/Va416x0/Drv/AdcSampler/AdcSampler.cpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.cpp
@@ -135,7 +135,7 @@ void AdcSampler::configure(const AdcConfig& config) {
     for (U32 i = 0; i < config.muxEnPinCount; i++) {
         auto pin = &config.muxEnPins[i];
         // Default MUX enable pins to be disabled
-        auto pinDisabled = (config.invertMuxEn == INVERT_MUX_EN) ? Fw::Logic::HIGH : Fw::Logic::LOW;
+        auto pinDisabled = (config.muxEnActive == MUX_PIN_ACTIVE_HIGH) ? Fw::Logic::LOW : Fw::Logic::HIGH;
         pin->out(pinDisabled);
         pin->configure_as_gpio(Fw::Direction::OUT);
     }
@@ -258,7 +258,8 @@ void AdcSampler::startReadInner() {
             if (previousMuxEnIndex != ADC_MUX_PINS_EN_MAX) {
                 FW_ASSERT(previousMuxEnIndex < this->m_config->muxEnPinCount, previousMuxEnIndex,
                           this->m_lastMuxRequest, this->m_config->muxEnPinCount);
-                auto pinDisabled = (this->m_config->invertMuxEn == INVERT_MUX_EN) ? Fw::Logic::HIGH : Fw::Logic::LOW;
+                auto pinDisabled =
+                    (this->m_config->muxEnActive == MUX_PIN_ACTIVE_HIGH) ? Fw::Logic::LOW : Fw::Logic::HIGH;
                 this->m_config->muxEnPins[previousMuxEnIndex].out(pinDisabled);
                 // Delay after disabling the previous MUX_EN pin
                 Va416x0Mmio::Amba::memory_barrier();
@@ -269,7 +270,8 @@ void AdcSampler::startReadInner() {
             if (muxEnIndex != ADC_MUX_PINS_EN_MAX) {
                 FW_ASSERT(muxEnIndex < this->m_config->muxEnPinCount, muxEnIndex, this->m_curRequest,
                           this->m_config->muxEnPinCount);
-                auto pinEnabled = (this->m_config->invertMuxEn == INVERT_MUX_EN) ? Fw::Logic::LOW : Fw::Logic::HIGH;
+                auto pinEnabled =
+                    (this->m_config->muxEnActive == MUX_PIN_ACTIVE_HIGH) ? Fw::Logic::HIGH : Fw::Logic::LOW;
                 this->m_config->muxEnPins[muxEnIndex].out(pinEnabled);
             }
         }

--- a/Va416x0/Drv/AdcSampler/AdcSampler.cpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.cpp
@@ -135,7 +135,7 @@ void AdcSampler::configure(const AdcConfig& config) {
     for (U32 i = 0; i < config.muxEnPinCount; i++) {
         auto pin = &config.muxEnPins[i];
         // Default MUX enable pins to be disabled
-        auto pinDisabled = config.invertMuxEn ? Fw::Logic::HIGH : Fw::Logic::LOW;
+        auto pinDisabled = (config.invertMuxEn == INVERT_MUX_EN) ? Fw::Logic::HIGH : Fw::Logic::LOW;
         pin->out(pinDisabled);
         pin->configure_as_gpio(Fw::Direction::OUT);
     }
@@ -258,7 +258,7 @@ void AdcSampler::startReadInner() {
             if (previousMuxEnIndex != ADC_MUX_PINS_EN_MAX) {
                 FW_ASSERT(previousMuxEnIndex < this->m_config->muxEnPinCount, previousMuxEnIndex,
                           this->m_lastMuxRequest, this->m_config->muxEnPinCount);
-                auto pinDisabled = this->m_config->invertMuxEn ? Fw::Logic::HIGH : Fw::Logic::LOW;
+                auto pinDisabled = (this->m_config->invertMuxEn == INVERT_MUX_EN) ? Fw::Logic::HIGH : Fw::Logic::LOW;
                 this->m_config->muxEnPins[previousMuxEnIndex].out(pinDisabled);
                 // Delay after disabling the previous MUX_EN pin
                 Va416x0Mmio::Amba::memory_barrier();
@@ -269,7 +269,7 @@ void AdcSampler::startReadInner() {
             if (muxEnIndex != ADC_MUX_PINS_EN_MAX) {
                 FW_ASSERT(muxEnIndex < this->m_config->muxEnPinCount, muxEnIndex, this->m_curRequest,
                           this->m_config->muxEnPinCount);
-                auto pinEnabled = this->m_config->invertMuxEn ? Fw::Logic::LOW : Fw::Logic::HIGH;
+                auto pinEnabled = (this->m_config->invertMuxEn == INVERT_MUX_EN) ? Fw::Logic::LOW : Fw::Logic::HIGH;
                 this->m_config->muxEnPins[muxEnIndex].out(pinEnabled);
             }
         }

--- a/Va416x0/Drv/AdcSampler/AdcSampler.hpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.hpp
@@ -50,6 +50,11 @@ U32 static inline adc_sampler_request(U16 chan_en, U8 cnt, bool is_sweep, bool i
 // FIXME: should be Va416x0Drv
 namespace Va416x0 {
 
+enum AdcMuxEnInversion {
+    NO_MUX_EN_INVERSION,
+    INVERT_MUX_EN,
+};
+
 struct AdcConfig {
     //! Array of GPIO pins used to enable a MUX. When an ADC request specifies enable_pin=i, the
     //! pin at index i is used. If a request specifies enable_pin=ADC_MUX_PINS_EN_MAX, no enable
@@ -58,7 +63,7 @@ struct AdcConfig {
     //! Number of MUX_EN pins
     U8 muxEnPinCount;
     //! Invert MUX_EN pin values so that pins are enabled when LOW and disabled when HIGH
-    bool invertMuxEn;
+    AdcMuxEnInversion invertMuxEn;
     //! Array of GPIO pins used for MUX address selection. All MUXes must use the same pins for
     //! address selection signals. The pin at index i is the pin that sets 1 << i when selecting
     //! the MUX channel

--- a/Va416x0/Drv/AdcSampler/AdcSampler.hpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.hpp
@@ -50,9 +50,10 @@ U32 static inline adc_sampler_request(U16 chan_en, U8 cnt, bool is_sweep, bool i
 // FIXME: should be Va416x0Drv
 namespace Va416x0 {
 
-enum AdcMuxEnInversion {
-    NO_MUX_EN_INVERSION,
-    INVERT_MUX_EN,
+//! Sets the output value at which MUX_EN pins are active
+enum AdcMuxEnActive {
+    MUX_PIN_ACTIVE_HIGH,
+    MUX_PIN_ACTIVE_LOW,
 };
 
 struct AdcConfig {
@@ -62,8 +63,10 @@ struct AdcConfig {
     const Va416x0Mmio::Gpio::Pin* muxEnPins;
     //! Number of MUX_EN pins
     U8 muxEnPinCount;
-    //! Invert MUX_EN pin values so that pins are enabled when LOW and disabled when HIGH
-    AdcMuxEnInversion invertMuxEn;
+    //! Sets the output value at which each MUX_EN pin is active. Defaults to MUX_PIN_ACTIVE_HIGH
+    //! which means pins are enabled when HIGH and disabled when LOW. Set to MUX_PIN_ACTIVE_LOW to
+    //! invert these semantics so that pins are enabled when LOW and disabled when HIGH
+    AdcMuxEnActive muxEnActive;
     //! Array of GPIO pins used for MUX address selection. All MUXes must use the same pins for
     //! address selection signals. The pin at index i is the pin that sets 1 << i when selecting
     //! the MUX channel

--- a/Va416x0/Drv/AdcSampler/AdcSampler.hpp
+++ b/Va416x0/Drv/AdcSampler/AdcSampler.hpp
@@ -57,6 +57,8 @@ struct AdcConfig {
     const Va416x0Mmio::Gpio::Pin* muxEnPins;
     //! Number of MUX_EN pins
     U8 muxEnPinCount;
+    //! Invert MUX_EN pin values so that pins are enabled when LOW and disabled when HIGH
+    bool invertMuxEn;
     //! Array of GPIO pins used for MUX address selection. All MUXes must use the same pins for
     //! address selection signals. The pin at index i is the pin that sets 1 << i when selecting
     //! the MUX channel


### PR DESCRIPTION
Previously, `AdcSampler` assumed that MUX_EN pins always have inverted semantics where they are set HIGH to disable them and set LOW to enable them, but this is not always the case. This pull request makes these semantics configurable in the `AdcConfig` struct.