### PR TITLE
Removed BASE_CONFIG keyword from config-vorago cmake

### DIFF
--- a/default/config-vorago/CMakeLists.txt
+++ b/default/config-vorago/CMakeLists.txt
@@ -23,6 +23,5 @@ register_fprime_config(
     DEPENDS
         Fw_Types
     INTERFACE
-    BASE_CONFIG
 )
 


### PR DESCRIPTION
Removed BASE_CONFIG  from default/config-vorago/CMakeLists.txt (per LeStarch's recommendation) 